### PR TITLE
Allow user selected font

### DIFF
--- a/FSNotes/NoteCellView.swift
+++ b/FSNotes/NoteCellView.swift
@@ -68,4 +68,28 @@ class NoteCellView: NSTableCellView {
         let previewRight = preview.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -65)
         NSLayoutConstraint.activate([previewTop, previewLeft, dateRight, dateTop, previewRight])
     }
+    
+    
+    // This NoteCellView has multiple contained views; this method changes
+    // these views' color when the cell is selected.
+    override var backgroundStyle: NSView.BackgroundStyle {
+        set {
+            super.backgroundStyle = newValue
+            self.udpateSelectionHighlight()
+        }
+        get {
+            return super.backgroundStyle;
+        }
+    }
+    
+    func udpateSelectionHighlight() {
+        if ( self.backgroundStyle == NSView.BackgroundStyle.dark ) {
+            preview.textColor = NSColor.white
+            date.textColor = NSColor.white
+        } else if( self.backgroundStyle == NSView.BackgroundStyle.light ) {
+            let lightGray = NSColor(deviceRed: 0.6, green: 0.6, blue: 0.6, alpha: 1)
+            preview.textColor = lightGray
+            date.textColor = lightGray
+        }
+    }
 }

--- a/FSNotes/NoteCellView.swift
+++ b/FSNotes/NoteCellView.swift
@@ -16,10 +16,13 @@ class NoteCellView: NSTableCellView {
     
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-                
-        date.font = NSFont(name: "Source Code Pro", size: 10)
-        let font = NSFont(name: "Source Code Pro", size: 11)
-        preview.font = font
+        
+        var fontName = UserDefaults.standard.object(forKey: "noteFont") as? String
+        if (fontName == nil) {
+            fontName = "Source Code Pro"
+        }
+//        date.font    = NSFont(name: fontName!, size: 10)
+        preview.font = NSFont(name: fontName!, size: 11)
         
         name.sizeToFit()
         

--- a/FSNotes/PrefsViewController.swift
+++ b/FSNotes/PrefsViewController.swift
@@ -14,6 +14,7 @@ class PrefsViewController: NSViewController {
     @IBOutlet var externalEditorApp: NSTextField!
     @IBOutlet var previewApp: NSTextField!
     
+    @IBOutlet weak var noteFont: NSPopUpButton!
     @IBOutlet weak var horizontalRadio: NSButton!
     @IBOutlet weak var verticalRadio: NSButton!
     
@@ -72,6 +73,14 @@ class PrefsViewController: NSViewController {
         restart()
     }
     
+    @IBAction func changedNoteFont(_ sender: NSPopUpButton) {
+        guard let selectedNoteFont = noteFont.selectedItem?.title
+            else {return}
+        
+        UserDefaults.standard.set(selectedNoteFont, forKey: "noteFont")
+        controller?.setEditAreaFont()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -107,6 +116,15 @@ class PrefsViewController: NSViewController {
         }
         
         fileExtensionOutlet.stringValue = (controller?.getDefaultFileExtension())!
+
+        noteFont.addItems(withTitles: NSFontManager.shared().availableFontFamilies)
+        if (UserDefaults.standard.object(forKey: "noteFont") != nil) {
+            let chosenNoteFont = UserDefaults.standard.object(forKey: "noteFont") as! String
+            noteFont.selectItem(withTitle: chosenNoteFont)
+        }
+        else {
+            noteFont.selectItem(withTitle: "Source Code Pro")
+        }
     }
     
     func restart() {

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -63,7 +63,15 @@ class ViewController: NSViewController,
             editArea.string = notesTableView.notesList[0].content!
         }
         
-        let font = NSFont(name: "Source Code Pro", size: 13)
+        setEditAreaFont()
+    }
+    
+    func setEditAreaFont() {
+        var fontName = UserDefaults.standard.object(forKey: "noteFont") as? String
+        if (fontName == nil) {
+            fontName = "Source Code Pro"
+        }
+        let font = NSFont(name: fontName!, size: 13)
         editArea.font = font
     }
     


### PR DESCRIPTION
Being rather a fan of Helvetica for my notes, I have added some preliminary code to allow me to choose this in the preferences :)

However, in writing this code I felt the need for a deeper structural change, which I would rather defer to you. I am thinking of a centralised class that could handle config, for eg setting Source Sans Pro as the default. At present this is in three places or so.

Also, I am dynamically updating the note font, but wasn't sure how to dynamically update the preview font.

So, no probs if you'd rather not roll this in, although it would certainly be great to have prefs for font (and later, size), just like nvALT does.