### PR TITLE
Set window title to selected note title

### DIFF
--- a/FSNotes/AppDelegate.swift
+++ b/FSNotes/AppDelegate.swift
@@ -13,8 +13,11 @@ import CloudKit
 class AppDelegate: NSObject, NSApplicationDelegate {
     var mainWindowController: MainWindowController?
     
-    var appTitle = "FSNotes"
-    
+    var appTitle: String {
+        let name = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+        return name ?? Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as! String
+    }
+
     @IBAction func openHelp(_ sender: Any) {
         NSWorkspace.shared.open(URL(string: "https://github.com/glushchenko/fsnotes")!)
     }

--- a/FSNotes/AppDelegate.swift
+++ b/FSNotes/AppDelegate.swift
@@ -13,6 +13,8 @@ import CloudKit
 class AppDelegate: NSObject, NSApplicationDelegate {
     var mainWindowController: MainWindowController?
     
+    var appTitle = "FSNotes"
+    
     @IBAction func openHelp(_ sender: Any) {
         NSWorkspace.shared.open(URL(string: "https://github.com/glushchenko/fsnotes")!)
     }

--- a/FSNotes/EditTextView.swift
+++ b/FSNotes/EditTextView.swift
@@ -137,6 +137,8 @@ class EditTextView: NSTextView {
         
         let viewController = self.window?.contentViewController as! ViewController
         viewController.emptyEditAreaImage.isHidden = true
+        
+        self.window?.title = note.title
     }
     
     private static var timer: Timer?
@@ -224,6 +226,9 @@ class EditTextView: NSTextView {
         textStorage?.mutableString.setString("")
         subviews.removeAll()
         isEditable = false
+        
+        let appDelegate = NSApplication.shared.delegate as! AppDelegate
+        self.window?.title = appDelegate.appTitle
         
         let viewController = self.window?.contentViewController as! ViewController
         viewController.emptyEditAreaImage.isHidden = false


### PR DESCRIPTION
Some of my notes have long titles, and as a fan of the vertical layout, there sometimes isn't room to view the entire title in the notes list. This PR puts the selected note's title into the App window title.