### PR TITLE
Set cursor white when on dark-colored note backgrounds.

### DIFF
--- a/FSNotes/EditTextView.swift
+++ b/FSNotes/EditTextView.swift
@@ -29,6 +29,10 @@ class EditTextView: NSTextView {
     
     override func drawBackground(in rect: NSRect) {
         backgroundColor = UserDefaultsManagement.bgColor
+        
+        let isDarkBG = backgroundColor.brightnessComponent < 0.5
+        insertionPointColor = isDarkBG ? NSColor.white : NSColor.black
+        
         super.drawBackground(in: rect)
     }
     


### PR DESCRIPTION
See https://github.com/glushchenko/fsnotes/pull/87#issuecomment-356791250

This PR sets the text cursor to be white when on dark backgrounds.