### PR TITLE
Format dates as time only when date is sometime today.

### DIFF
--- a/FSNotes/DateFormatter+.swift
+++ b/FSNotes/DateFormatter+.swift
@@ -1,0 +1,28 @@
+//
+//  DateFormatter+.swift
+//  FSNotes
+//
+//  Created by Jeff Hanbury on 25/03/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import Foundation
+
+
+extension DateFormatter {
+    func formatDateForDisplay(_ date: Date) -> String {
+        dateStyle = .short
+        timeStyle = .none
+        locale = NSLocale.autoupdatingCurrent
+        return string(from: date)
+    }
+    
+    func formatTimeForDisplay(_ date: Date) -> String {
+        dateStyle = .none
+        timeStyle = .short
+        locale = NSLocale.autoupdatingCurrent
+        return string(from: date)
+    }
+
+}
+

--- a/FSNotes/Model/Note+CoreDataClass.swift
+++ b/FSNotes/Model/Note+CoreDataClass.swift
@@ -170,16 +170,18 @@ public class Note: NSManagedObject {
     }
     
     @objc func getDateForLabel() -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = DateFormatter.Style.short
-        dateFormatter.timeStyle = DateFormatter.Style.none
-        dateFormatter.locale = NSLocale.autoupdatingCurrent
-        
-        if let date = self.modifiedLocalAt {
-            return dateFormatter.string(from: date)
+        guard let date = self.modifiedLocalAt else {
+            return "-"
         }
         
-        return "-"
+        let dateFormatter = DateFormatter()
+        let calendar = NSCalendar.current
+        if calendar.isDateInToday(date) {
+            return dateFormatter.formatTimeForDisplay(date)
+        }
+        else {
+            return dateFormatter.formatDateForDisplay(date)
+        }
     }
     
     func getContent() -> NSAttributedString? {


### PR DESCRIPTION
If a note is modified sometime today, display its date as a time eg "1:30 PM" instead of just the date.

As you can see I put the bulk of this into a little extension to `DateFormatter`. Solves https://github.com/glushchenko/fsnotes/issues/118.