### PR TITLE
Cancel auto bullets

### DIFF
--- a/FSNotes/EditTextView.swift
+++ b/FSNotes/EditTextView.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import Down
 import Highlightr
+import Carbon.HIToolbox
 
 class EditTextView: NSTextView {
     public static var note: Note?
@@ -59,11 +60,11 @@ class EditTextView: NSTextView {
     @IBAction func editorMenuItem(_ sender: Any) {
         let keyEquivalent = (sender as AnyObject).keyEquivalent.lowercased()
         
-        let dict = ["b": 11, "i": 34, "j": 38, "y": 16, "u": 32, "1": 18, "2": 19, "3": 20, "4": 21, "5": 23, "6": 22] as [String: UInt16]
+        let dict = ["b": kVK_ANSI_B, "i": kVK_ANSI_I, "j": kVK_ANSI_J, "y": kVK_ANSI_Y, "u": kVK_ANSI_U, "1": kVK_ANSI_1, "2": kVK_ANSI_2, "3": kVK_ANSI_3, "4": kVK_ANSI_4, "5": kVK_ANSI_5, "6": kVK_ANSI_6] as [String: Int]
         
         if (dict[keyEquivalent] != nil) {
-            let keyCode = dict[keyEquivalent]!
-            let modifier = (sender as AnyObject).keyEquivalentModifierMask.rawValue == 262144 ? 393475 : 0
+            let keyCode = UInt16(dict[keyEquivalent]!)
+            let modifier = (sender as AnyObject).keyEquivalentModifierMask == NSEvent.ModifierFlags.control ? 393475 : 0
             
             _ = formatShortcut(keyCode: keyCode, modifier: UInt(modifier))
         }
@@ -87,11 +88,11 @@ class EditTextView: NSTextView {
     
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         /* Skip command-shift-b conflicted with cmd-b */
-        if event.modifierFlags.contains(NSEvent.ModifierFlags.command) && event.modifierFlags.contains(NSEvent.ModifierFlags.shift) && event.keyCode == 11 {
+        if event.modifierFlags.contains(.command) && event.modifierFlags.contains(.shift) && event.keyCode == 11 {
             return super.performKeyEquivalent(with: event)
         }
         
-        if (event.modifierFlags.contains(NSEvent.ModifierFlags.command) || event.modifierFlags.rawValue == 393475) {
+        if (event.modifierFlags.contains(.command) || event.modifierFlags.rawValue == 393475) {
             if (formatShortcut(keyCode: event.keyCode, modifier: event.modifierFlags.rawValue as UInt)) {
                 return true
             }
@@ -425,8 +426,8 @@ class EditTextView: NSTextView {
         guard let note = EditTextView.note else {
             return
         }
-        
-        if event.keyCode == 0x24 {
+    
+        if event.keyCode == kVK_Return {
             super.keyDown(with: event)
             
             let formatter = TextFormatter(textView: self, note: note)
@@ -434,8 +435,8 @@ class EditTextView: NSTextView {
             return
         }
         
-        if event.keyCode == 48 {
-            if event.modifierFlags.rawValue == 131330 {
+        if event.keyCode == kVK_Tab {
+            if event.modifierFlags.contains(.shift) {
                 let formatter = TextFormatter(textView: self, note: note)
                 formatter.unTab()
                 saveCursorPosition()

--- a/FSNotes/NotesTableView.swift
+++ b/FSNotes/NotesTableView.swift
@@ -107,7 +107,7 @@ class NotesTableView: NSTableView, NSTableViewDataSource,
     }
     
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if ([kVK_ANSI_8, kVK_ANSI_J, kVK_ANSI_K].contains(Int(event.keyCode)) && event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        if ([kVK_ANSI_8, kVK_ANSI_J, kVK_ANSI_K].contains(Int(event.keyCode)) && event.modifierFlags.contains(.command)) {
             return true
         }
         

--- a/FSNotes/SearchTextField.swift
+++ b/FSNotes/SearchTextField.swift
@@ -27,7 +27,7 @@ class SearchTextField: NSTextField {
             event.keyCode == 53
             || (
                 [37, 45].contains(event.keyCode)
-                && event.modifierFlags.contains(NSEvent.ModifierFlags.command)
+                && event.modifierFlags.contains(.command)
             )
         ) {
             return true

--- a/FSNotes/TextFormatter.swift
+++ b/FSNotes/TextFormatter.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import Carbon.HIToolbox
+
 
 #if os(OSX)
     import Cocoa
@@ -270,13 +272,21 @@ public class TextFormatter {
         let prevString = nsString.substring(with: prevParagraphRange)
         let nsPrev = prevString as NSString
         
-        guard let regex = try? NSRegularExpression(pattern: "^( |\t)*([-|–|\\+]{1} )"),
+        guard let regex = try? NSRegularExpression(pattern: "^( |\t)*([-|–|—|*|\\+]{1} )"),
             let regexDigits = try? NSRegularExpression(pattern: "^(?: |\t)*([0-9])+. ") else {
             return
         }
         
         if let match = regex.firstMatch(in: prevString, range: NSRange(0..<nsPrev.length)) {
             let prefix = nsPrev.substring(with: match.range)
+            
+            if prevString == prefix + "\n" {
+                // Remove the previous line.
+                textView.setSelectedRange(prevParagraphRange)
+                textView.delete(self)
+                return
+            }
+            
             textView.insertText(prefix, replacementRange: textView.selectedRange())
             return
         }

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: NSViewController,
         }
         
         setTableRowHeight()
-        
+                
         super.viewDidAppear()
     }
     
@@ -365,7 +365,7 @@ class ViewController: NSViewController,
         }
         
         // Focus search field shortcut (cmd-L)
-        if (event.keyCode == 37 && event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        if (event.keyCode == 37 && event.modifierFlags.contains(.command)) {
             search.becomeFirstResponder()
         }
         
@@ -381,8 +381,8 @@ class ViewController: NSViewController,
         // Note edit mode and select file name (cmd-r)
         if (
             event.keyCode == 15
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.command)
-            && !event.modifierFlags.contains(NSEvent.ModifierFlags.shift)
+            && event.modifierFlags.contains(.command)
+            && !event.modifierFlags.contains(.shift)
         ) {
             renameNote(selectedRow: notesTableView.selectedRow)
         }
@@ -390,8 +390,8 @@ class ViewController: NSViewController,
         // Make note shortcut (cmd-n)
         if (
             event.keyCode == 45
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.command)
-            && !event.modifierFlags.contains(NSEvent.ModifierFlags.shift)
+            && event.modifierFlags.contains(.command)
+            && !event.modifierFlags.contains(.shift)
         ) {
             makeNote(NSTextField())
         }
@@ -399,32 +399,32 @@ class ViewController: NSViewController,
         // Make note shortcut (cmd-n)
         if (
             event.keyCode == 45
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.command)
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.shift)
+            && event.modifierFlags.contains(.command)
+            && event.modifierFlags.contains(.shift)
         ) {
             fileMenuNewRTF(NSTextField())
         }
         
         // Pin note shortcut (cmd-8)
-        if (event.keyCode == 28 && event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        if (event.keyCode == 28 && event.modifierFlags.contains(.command)) {
             pin(notesTableView.selectedRowIndexes)
         }
         
         // Next note (cmd-j)
-        if (event.keyCode == 38 && event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        if (event.keyCode == 38 && event.modifierFlags.contains(.command)) {
             notesTableView.selectNext()
         }
         
         // Prev note (cmd-k)
-        if (event.keyCode == 40 && event.modifierFlags.contains(NSEvent.ModifierFlags.command)) {
+        if (event.keyCode == 40 && event.modifierFlags.contains(.command)) {
             notesTableView.selectPrev()
         }
                 
         // Open in external editor (cmd-control-e)
         if (
             event.keyCode == 14
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.command)
-            && event.modifierFlags.contains(NSEvent.ModifierFlags.control)
+            && event.modifierFlags.contains(.command)
+            && event.modifierFlags.contains(.control)
         ) {
             external(selectedRow: notesTableView.selectedRow)
         }


### PR DESCRIPTION
This PR removes the last bullet in a list if it was left empty. In other words, if you press enter after an auto-created bullet without entering any bullet text, the bullet is removed. This seems common behaviour in other apps.

I've also included em-dash and asterisk in the list of acceptable bullet characters.

Finally, I replaced a bunch of hard-coded hex and int values with named constants. Hope this is OK — I found the hard-coded values pretty hard to interpret. In fact, there's still at least one that I haven't been able to identify (`393475`), and there are numerous more that could be replaced throughout, but I didn't want to go too far right now.