### PR TITLE
Brackets and bullets

### DIFF
--- a/FSNotes/EditTextView.swift
+++ b/FSNotes/EditTextView.swift
@@ -431,7 +431,6 @@ class EditTextView: NSTextView {
             "(" : ")",
             "[" : "]",
             "{" : "}",
-            "'" : "'",
             "\"" : "\"",
         ]
         if UserDefaultsManagement.autocloseBrackets,

--- a/FSNotes/TextFormatter.swift
+++ b/FSNotes/TextFormatter.swift
@@ -272,7 +272,7 @@ public class TextFormatter {
         let prevString = nsString.substring(with: prevParagraphRange)
         let nsPrev = prevString as NSString
         
-        guard let regex = try? NSRegularExpression(pattern: "^( |\t)*([-|–|—|*|\\+]{1} )"),
+        guard let regex = try? NSRegularExpression(pattern: "^( |\t)*([-|–|—|*|•|\\+]{1} )"),
             let regexDigits = try? NSRegularExpression(pattern: "^(?: |\t)*([0-9])+. ") else {
             return
         }


### PR DESCRIPTION
* Removes single quote `'` from the list of recognised brackets characters to auto-pair. See #152.
* Adds the bullet character `•` (opt-8) to the list of recognised bullet characters, it being the most obvious bullet character there is :laughing: