### PR TITLE
Reinstate changeable notes area background colour.

### DIFF
--- a/FSNotes/Extensions/NSView+.swift
+++ b/FSNotes/Extensions/NSView+.swift
@@ -9,7 +9,7 @@
 import Cocoa
 
 extension NSView {
-    var backgroundColor: NSColor? {
+    var viewBackgroundColor: NSColor? {
         get {
             if let colorRef = self.layer?.backgroundColor {
                 return NSColor(cgColor: colorRef)

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -39,7 +39,7 @@ class ViewController: NSViewController,
         self.view.window!.titlebarAppearsTransparent = true
         
         if (sidebarSplitView.subviews.count > 1) {
-            sidebarSplitView.subviews[1].backgroundColor = NSColor.white
+            sidebarSplitView.subviews[1].viewBackgroundColor = NSColor.white
         }
         
         // editarea paddings


### PR DESCRIPTION
In recent versions, the background colour preference does nothing.

Back in 1.5.2 an extension to NSView was introduced which added a computed property called `backgroundColor`. Unfortunately this overwrote the property with the same name that is provided by NSTextView, thereby breaking the code which changes the background colour according to the preference setting. This PR fixes that by removing the naming conflict.