### PR TITLE
WIP: Extract core code into framework

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pbxproj merge=union
+

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,4 @@
+included: # paths to include during linting. `--path` is ignored if present.
+  - FSNotesCore
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Pods

--- a/FSNotes iOS/AppDelegate.swift
+++ b/FSNotes iOS/AppDelegate.swift
@@ -12,6 +12,8 @@ import Solar
 import NightNight
 import CoreLocation
 
+import FSNotesCore_iOS
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/FSNotes iOS/EditorViewController.swift
+++ b/FSNotes iOS/EditorViewController.swift
@@ -150,9 +150,7 @@ class EditorViewController: UIViewController, UITextViewDelegate {
         switch note.type {
         case .PlainText:
             editArea.font = UserDefaultsManagement.noteFont
-        case .RichText:
-            break
-        case .Markdown:
+        default:
             return
         }
     }

--- a/FSNotes iOS/Extensions/UIFont+.swift
+++ b/FSNotes iOS/Extensions/UIFont+.swift
@@ -1,0 +1,57 @@
+//
+//  UIFont+.swift
+//  FSNotes
+//
+//  Created by Oleksandr Glushchenko on 3/6/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import UIKit
+
+extension UIFont {
+    var isBold: Bool {
+        return fontDescriptor.symbolicTraits.contains(.traitBold)
+    }
+    
+    var isItalic: Bool {
+        return fontDescriptor.symbolicTraits.contains(.traitItalic)
+    }
+    
+    func italic() -> UIFont {
+        if let descriptor = fontDescriptor.withSymbolicTraits(.traitItalic) {
+            return UIFont(descriptor: descriptor, size: 0)
+        }
+        
+        return UserDefaultsManagement.noteFont
+    }
+    
+    func bold() -> UIFont {
+        if let descriptor = fontDescriptor.withSymbolicTraits(.traitBold) {
+            return UIFont(descriptor: descriptor, size: 0)
+        }
+        
+        return UserDefaultsManagement.noteFont
+    }
+    
+    func unBold() -> UIFont {
+        var symTraits = fontDescriptor.symbolicTraits
+        symTraits.remove(.traitBold)
+        
+        if let descriptor = fontDescriptor.withSymbolicTraits(symTraits) {
+            return UIFont(descriptor: descriptor, size: 0)
+        }
+        
+        return UserDefaultsManagement.noteFont
+    }
+    
+    func unItalic() -> UIFont {
+        var symTraits = fontDescriptor.symbolicTraits
+        symTraits.remove(.traitItalic)
+        
+        if let descriptor = fontDescriptor.withSymbolicTraits(symTraits) {
+            return UIFont(descriptor: descriptor, size: 0)
+        }
+        
+        return UserDefaultsManagement.noteFont
+    }
+}

--- a/FSNotes.xcodeproj/project.pbxproj
+++ b/FSNotes.xcodeproj/project.pbxproj
@@ -8,7 +8,28 @@
 
 /* Begin PBXBuildFile section */
 		275592971F3AE9B5006B8988 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275592961F3AE9B5006B8988 /* MainWindowController.swift */; };
-		6F46BBE71F55320E000D7DB2 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F46BBE61F55320E000D7DB2 /* String+.swift */; };
+		6F13BB0D20FEDDF50005E120 /* FSNotesCore_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */; };
+		6F13BB1620FEDDF50005E120 /* FSNotesCore_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F13BB0620FEDDF50005E120 /* FSNotesCore_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F13BB1920FEDDF50005E120 /* FSNotesCore_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */; };
+		6F13BB1B20FEDDF50005E120 /* FSNotesCore_macOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6F13BB5520FEDE560005E120 /* FSNotesCore_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */; };
+		6F13BB5C20FEDE560005E120 /* FSNotesCore_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB5B20FEDE560005E120 /* FSNotesCore_iOSTests.swift */; };
+		6F13BB6120FEDE560005E120 /* FSNotesCore_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */; };
+		6F13BB6220FEDE560005E120 /* FSNotesCore_iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6F13BB6A20FEE0450005E120 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2820FEDE230005E120 /* DateFormatter+.swift */; };
+		6F13BB6B20FEE0460005E120 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2820FEDE230005E120 /* DateFormatter+.swift */; };
+		6F13BB6C20FEE04A0005E120 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2920FEDE230005E120 /* String+.swift */; };
+		6F13BB6D20FEE04B0005E120 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2920FEDE230005E120 /* String+.swift */; };
+		6F13BB6E20FEE04F0005E120 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2A20FEDE230005E120 /* URL+.swift */; };
+		6F13BB6F20FEE04F0005E120 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB2A20FEDE230005E120 /* URL+.swift */; };
+		6F13BB7020FEE0A80005E120 /* NSView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB3620FEDE230005E120 /* NSView+.swift */; };
+		6F13BB7120FEE0DD0005E120 /* UserDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB3820FEDE230005E120 /* UserDataService.swift */; };
+		6F13BB7220FEE1E30005E120 /* DateFormatter+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4520FEDE330005E120 /* DateFormatter+Tests.swift */; };
+		6F13BB7320FEE1E40005E120 /* DateFormatter+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4520FEDE330005E120 /* DateFormatter+Tests.swift */; };
+		6F13BB7420FEE1E80005E120 /* String+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4620FEDE330005E120 /* String+Tests.swift */; };
+		6F13BB7520FEE1E80005E120 /* String+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4620FEDE330005E120 /* String+Tests.swift */; };
+		6F13BB7620FEE1F20005E120 /* UserDataServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4120FEDE330005E120 /* UserDataServiceTests.swift */; };
+		6F13BB7920FEE6070005E120 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76025C2204F2820000B9F59 /* UIFont+.swift */; };
 		7116B6EF541108F7A48EBF4A /* Pods_FSNotes__iCloud_Documents_.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B1EC33343C49C1F21859483 /* Pods_FSNotes__iCloud_Documents_.framework */; };
 		93D1825473D129F6D510814D /* Pods_FSNotes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D77671B81FACEDDE00DDF28D /* Pods_FSNotes.framework */; };
 		D7038E1D20FA86C100A54E69 /* SharingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7038E1C20FA86C100A54E69 /* SharingService.swift */; };
@@ -51,8 +72,6 @@
 		D7271FAE2052803500033D0C /* unindent@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D7271FA82052803400033D0C /* unindent@3x.png */; };
 		D7271FAF2052803500033D0C /* indent@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D7271FA92052803500033D0C /* indent@3x.png */; };
 		D7271FB02052C77600033D0C /* pin.png in Resources */ = {isa = PBXBuildFile; fileRef = D7D3D5191F4483EA00D152FE /* pin.png */; };
-		D72A19992020AB940025CF5B /* UserDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72A19982020AB940025CF5B /* UserDataService.swift */; };
-		D72A199A2020AB940025CF5B /* UserDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72A19982020AB940025CF5B /* UserDataService.swift */; };
 		D73290BA2099F0AB0003F647 /* UndoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78678CA2093AE10001A6620 /* UndoData.swift */; };
 		D735E5BD1F2EF66000173215 /* NoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BC1F2EF66000173215 /* NoteCellView.swift */; };
 		D735E5BF1F2F001500173215 /* NoteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BE1F2F001500173215 /* NoteRowView.swift */; };
@@ -64,9 +83,6 @@
 		D74112281FABA21B00AB619A /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74112271FABA21B00AB619A /* MainWindow.swift */; };
 		D74112291FABA29100AB619A /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74112271FABA21B00AB619A /* MainWindow.swift */; };
 		D7465F28207F2CD600E46A52 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D7465F27207F2CD600E46A52 /* Images.xcassets */; };
-		D7475F552069245B00233126 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7475F542069245B00233126 /* DateFormatter+.swift */; };
-		D7475F562069245B00233126 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7475F542069245B00233126 /* DateFormatter+.swift */; };
-		D7475F572069245B00233126 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7475F542069245B00233126 /* DateFormatter+.swift */; };
 		D7508FC81F337E850047AB76 /* SearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7508FC71F337E850047AB76 /* SearchTextField.swift */; };
 		D7508FCE1F3438540047AB76 /* PrefsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7508FCD1F3438540047AB76 /* PrefsViewController.swift */; };
 		D75EE7F72078B22D0055F159 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75EE7F62078B22D0055F159 /* SidebarItem.swift */; };
@@ -88,7 +104,6 @@
 		D76025BF204F078A000B9F59 /* bold@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D76025BC204F078A000B9F59 /* bold@3x.png */; };
 		D76025C0204F078A000B9F59 /* bold@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D76025BD204F078A000B9F59 /* bold@2x.png */; };
 		D76025C1204F078A000B9F59 /* bold.png in Resources */ = {isa = PBXBuildFile; fileRef = D76025BE204F078A000B9F59 /* bold.png */; };
-		D76025C4204F2849000B9F59 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76025C2204F2820000B9F59 /* UIFont+.swift */; };
 		D76447DC1F3A4F0700965F01 /* UserDefaultsManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76447DB1F3A4F0700965F01 /* UserDefaultsManagement.swift */; };
 		D7679376201F0BFD000F7BBF /* SortBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7679375201F0BFD000F7BBF /* SortBy.swift */; };
 		D7679377201F0BFD000F7BBF /* SortBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7679375201F0BFD000F7BBF /* SortBy.swift */; };
@@ -116,8 +131,6 @@
 		D7A65C5920F11C38003E5ADC /* LanguageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A65C5820F11C38003E5ADC /* LanguageType.swift */; };
 		D7A65C5A20F11C38003E5ADC /* LanguageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A65C5820F11C38003E5ADC /* LanguageType.swift */; };
 		D7A9FD311FCB4873008ED23C /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A9FD301FCB4873008ED23C /* MarkdownView.swift */; };
-		D7ADFD0E2064143D00B531F9 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADFD0D2064143D00B531F9 /* URL+.swift */; };
-		D7ADFD0F2064285900B531F9 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADFD0D2064143D00B531F9 /* URL+.swift */; };
 		D7ADFD112066CF9400B531F9 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7ADFD102066CF9400B531F9 /* CoreLocation.framework */; };
 		D7B024A72019BCF3008544C3 /* NoteAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B024A62019BCF3008544C3 /* NoteAttribute.swift */; };
 		D7B024A82019BCF3008544C3 /* NoteAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B024A62019BCF3008544C3 /* NoteAttribute.swift */; };
@@ -133,7 +146,6 @@
 		D7BBCA7C208C7523002CE3C3 /* tag.png in Resources */ = {isa = PBXBuildFile; fileRef = D7BBCA7B208C7523002CE3C3 /* tag.png */; };
 		D7BBCA7D208C7523002CE3C3 /* tag.png in Resources */ = {isa = PBXBuildFile; fileRef = D7BBCA7B208C7523002CE3C3 /* tag.png */; };
 		D7BDFE59201F671900897A58 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E025071F3B6DDB00EDDA32 /* Storage.swift */; };
-		D7BDFE5A201F677B00897A58 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F46BBE61F55320E000D7DB2 /* String+.swift */; };
 		D7BDFE5D201F677B00897A58 /* UserDefaultsManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76447DB1F3A4F0700965F01 /* UserDefaultsManagement.swift */; };
 		D7BDFE60201F677B00897A58 /* NoteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D708AC662000EF5800A1760F /* NoteType.swift */; };
 		D7BDFE61201F677B00897A58 /* SortBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7679375201F0BFD000F7BBF /* SortBy.swift */; };
@@ -150,8 +162,6 @@
 		D7CAD6AB20DD50A500FF4674 /* tag_red.png in Resources */ = {isa = PBXBuildFile; fileRef = D7CAD6A920DD509800FF4674 /* tag_red.png */; };
 		D7CB9905207E5AE300037E91 /* SidebarTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CB9904207E5AE300037E91 /* SidebarTableRowView.swift */; };
 		D7CB9906207E5AE300037E91 /* SidebarTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CB9904207E5AE300037E91 /* SidebarTableRowView.swift */; };
-		D7CB990B207E9F3500037E91 /* NSView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CB990A207E9F3500037E91 /* NSView+.swift */; };
-		D7CB990C207E9F3500037E91 /* NSView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CB990A207E9F3500037E91 /* NSView+.swift */; };
 		D7CD5F681F508E74006AA35D /* SourceCodePro-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D7CD5F671F508E6A006AA35D /* SourceCodePro-Bold.ttf */; };
 		D7CD5F691F508E74006AA35D /* SourceCodePro-BoldIt.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D7CD5F661F508E6A006AA35D /* SourceCodePro-BoldIt.ttf */; };
 		D7CD5F6C1F51185F006AA35D /* NSFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CD5F6B1F51185F006AA35D /* NSFont+.swift */; };
@@ -164,7 +174,6 @@
 		D7D03BC6205C6ED200D96A6D /* undo@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D7D03BC3205C6ED100D96A6D /* undo@2x.png */; };
 		D7D03BC7205C6ED200D96A6D /* undo.png in Resources */ = {isa = PBXBuildFile; fileRef = D7D03BC4205C6ED200D96A6D /* undo.png */; };
 		D7D03BC8205C6ED200D96A6D /* undo@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D7D03BC5205C6ED200D96A6D /* undo@3x.png */; };
-		D7D3184A2086771000FEB5EA /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADFD0D2064143D00B531F9 /* URL+.swift */; };
 		D7D372F4207B5B0F00AFBD9F /* SidebarNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D372F3207B5B0F00AFBD9F /* SidebarNotesView.swift */; };
 		D7D372F5207B5B0F00AFBD9F /* SidebarNotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D372F3207B5B0F00AFBD9F /* SidebarNotesView.swift */; };
 		D7D372F7207BB09500AFBD9F /* SidebarProjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D372F6207BB09500AFBD9F /* SidebarProjectView.swift */; };
@@ -218,7 +227,6 @@
 		D7E81C3F1F925B5F00416A91 /* NSFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7CD5F6B1F51185F006AA35D /* NSFont+.swift */; };
 		D7E81C411F925B5F00416A91 /* SearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7508FC71F337E850047AB76 /* SearchTextField.swift */; };
 		D7E81C421F925B5F00416A91 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275592961F3AE9B5006B8988 /* MainWindowController.swift */; };
-		D7E81C431F925B5F00416A91 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F46BBE61F55320E000D7DB2 /* String+.swift */; };
 		D7E81C441F925B5F00416A91 /* NoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BC1F2EF66000173215 /* NoteCellView.swift */; };
 		D7E81C461F925B5F00416A91 /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79FE8A01F77D04A00113CFD /* Note.swift */; };
 		D7E81C4B1F925B5F00416A91 /* DownView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D71C4A4D1F520F0E00EBA30B /* DownView.bundle */; };
@@ -250,6 +258,48 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6F13BB0E20FEDDF50005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13BB0320FEDDF40005E120;
+			remoteInfo = "FSNotesCore macOS";
+		};
+		6F13BB1020FEDDF50005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D7793C6E1F211C6000CA39B7;
+			remoteInfo = FSNotes;
+		};
+		6F13BB1720FEDDF50005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13BB0320FEDDF40005E120;
+			remoteInfo = "FSNotesCore macOS";
+		};
+		6F13BB5620FEDE560005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13BB4B20FEDE550005E120;
+			remoteInfo = "FSNotesCore iOS";
+		};
+		6F13BB5820FEDE560005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D7679385201F21F5000F7BBF;
+			remoteInfo = "FSNotes iOS";
+		};
+		6F13BB5F20FEDE560005E120 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F13BB4B20FEDE550005E120;
+			remoteInfo = "FSNotesCore iOS";
+		};
 		D75F333E205EC34800CC887E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D7793C671F211C6000CA39B7 /* Project object */;
@@ -260,6 +310,28 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		6F13BB1A20FEDDF50005E120 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6F13BB1B20FEDDF50005E120 /* FSNotesCore_macOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB6620FEDE560005E120 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6F13BB6220FEDE560005E120 /* FSNotesCore_iOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D713542C2042D46E00E3776F /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -291,7 +363,25 @@
 		507AC3FABAE4AA03A2ECBBE5 /* Pods-FSNotes (iCloud Documents).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes (iCloud Documents).release.xcconfig"; path = "Pods/Target Support Files/Pods-FSNotes (iCloud Documents)/Pods-FSNotes (iCloud Documents).release.xcconfig"; sourceTree = "<group>"; };
 		5819B06A38119683938E2D1E /* Pods_FSNotes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FSNotes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63E7A6CEB578A475FCE2C47F /* Pods-FSNotes (CloudKit).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes (CloudKit).debug.xcconfig"; path = "Pods/Target Support Files/Pods-FSNotes (CloudKit)/Pods-FSNotes (CloudKit).debug.xcconfig"; sourceTree = "<group>"; };
-		6F46BBE61F55320E000D7DB2 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FSNotesCore_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F13BB0620FEDDF50005E120 /* FSNotesCore_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FSNotesCore_macOS.h; sourceTree = "<group>"; };
+		6F13BB0720FEDDF50005E120 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F13BB0C20FEDDF50005E120 /* FSNotesCore macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FSNotesCore macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F13BB1520FEDDF50005E120 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F13BB2820FEDE230005E120 /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
+		6F13BB2920FEDE230005E120 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		6F13BB2A20FEDE230005E120 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
+		6F13BB3620FEDE230005E120 /* NSView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+.swift"; sourceTree = "<group>"; };
+		6F13BB3820FEDE230005E120 /* UserDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataService.swift; sourceTree = "<group>"; };
+		6F13BB4120FEDE330005E120 /* UserDataServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataServiceTests.swift; sourceTree = "<group>"; };
+		6F13BB4520FEDE330005E120 /* DateFormatter+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Tests.swift"; sourceTree = "<group>"; };
+		6F13BB4620FEDE330005E120 /* String+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Tests.swift"; sourceTree = "<group>"; };
+		6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FSNotesCore_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F13BB4E20FEDE560005E120 /* FSNotesCore_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FSNotesCore_iOS.h; sourceTree = "<group>"; };
+		6F13BB4F20FEDE560005E120 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6F13BB5420FEDE560005E120 /* FSNotesCore iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FSNotesCore iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6F13BB5B20FEDE560005E120 /* FSNotesCore_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FSNotesCore_iOSTests.swift; sourceTree = "<group>"; };
+		6F13BB5D20FEDE560005E120 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B1EC33343C49C1F21859483 /* Pods_FSNotes__iCloud_Documents_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FSNotes__iCloud_Documents_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FBB093D768873B26FFAABF6 /* Pods_FSNotes__CloudKit_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FSNotes__CloudKit_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD6B2C2AB86ECC93C9C8FD65 /* Pods-FSNotes iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FSNotes iOS/Pods-FSNotes iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -325,7 +415,6 @@
 		D7271FA72052803400033D0C /* unindent@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "unindent@2x.png"; sourceTree = "<group>"; };
 		D7271FA82052803400033D0C /* unindent@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "unindent@3x.png"; sourceTree = "<group>"; };
 		D7271FA92052803500033D0C /* indent@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "indent@3x.png"; sourceTree = "<group>"; };
-		D72A19982020AB940025CF5B /* UserDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataService.swift; sourceTree = "<group>"; };
 		D72E05861F5220D300977D02 /* Down.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Down.framework; sourceTree = "<group>"; };
 		D735E5B81F2E45CC00173215 /* icons.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = icons.icns; sourceTree = "<group>"; };
 		D735E5BC1F2EF66000173215 /* NoteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCellView.swift; sourceTree = "<group>"; };
@@ -336,7 +425,6 @@
 		D739955D2051D1AB009017EE /* italic.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = italic.png; sourceTree = "<group>"; };
 		D74112271FABA21B00AB619A /* MainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
 		D7465F27207F2CD600E46A52 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		D7475F542069245B00233126 /* DateFormatter+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "DateFormatter+.swift"; path = "FSNotes/DateFormatter+.swift"; sourceTree = SOURCE_ROOT; };
 		D74922111FACE9B100C45108 /* Down.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Down.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7508FC71F337E850047AB76 /* SearchTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextField.swift; sourceTree = "<group>"; };
 		D7508FCD1F3438540047AB76 /* PrefsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsViewController.swift; sourceTree = "<group>"; };
@@ -353,7 +441,7 @@
 		D76025BC204F078A000B9F59 /* bold@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bold@3x.png"; sourceTree = "<group>"; };
 		D76025BD204F078A000B9F59 /* bold@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bold@2x.png"; sourceTree = "<group>"; };
 		D76025BE204F078A000B9F59 /* bold.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = bold.png; sourceTree = "<group>"; };
-		D76025C2204F2820000B9F59 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		D76025C2204F2820000B9F59 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIFont+.swift"; path = "../../FSNotes/Extensions/UIFont+.swift"; sourceTree = "<group>"; };
 		D76447DB1F3A4F0700965F01 /* UserDefaultsManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManagement.swift; sourceTree = "<group>"; };
 		D7679375201F0BFD000F7BBF /* SortBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBy.swift; sourceTree = "<group>"; };
 		D7679386201F21F5000F7BBF /* FSNotes iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FSNotes iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -382,7 +470,6 @@
 		D7A415131F2FBDA00099B82C /* NotesTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesTableView.swift; sourceTree = "<group>"; };
 		D7A65C5820F11C38003E5ADC /* LanguageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageType.swift; sourceTree = "<group>"; };
 		D7A9FD301FCB4873008ED23C /* MarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownView.swift; sourceTree = "<group>"; };
-		D7ADFD0D2064143D00B531F9 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		D7ADFD102066CF9400B531F9 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.2.sdk/System/Library/Frameworks/CoreLocation.framework; sourceTree = DEVELOPER_DIR; };
 		D7B024A62019BCF3008544C3 /* NoteAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteAttribute.swift; sourceTree = "<group>"; };
 		D7B3391420DE0FB100B36460 /* TagList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagList.swift; sourceTree = "<group>"; };
@@ -397,7 +484,6 @@
 		D7CA2DA620C9B6EF00717769 /* NSMutableAttributedString+Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Font.swift"; sourceTree = "<group>"; };
 		D7CAD6A920DD509800FF4674 /* tag_red.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tag_red.png; sourceTree = "<group>"; };
 		D7CB9904207E5AE300037E91 /* SidebarTableRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTableRowView.swift; sourceTree = "<group>"; };
-		D7CB990A207E9F3500037E91 /* NSView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+.swift"; sourceTree = "<group>"; };
 		D7CD5F661F508E6A006AA35D /* SourceCodePro-BoldIt.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceCodePro-BoldIt.ttf"; sourceTree = "<group>"; };
 		D7CD5F671F508E6A006AA35D /* SourceCodePro-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceCodePro-Bold.ttf"; sourceTree = "<group>"; };
 		D7CD5F6B1F51185F006AA35D /* NSFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFont+.swift"; sourceTree = "<group>"; };
@@ -446,6 +532,36 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		6F13BB0120FEDDF40005E120 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB0920FEDDF50005E120 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB0D20FEDDF50005E120 /* FSNotesCore_macOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB4920FEDE550005E120 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB5120FEDE560005E120 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB5520FEDE560005E120 /* FSNotesCore_iOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D75F3333205EC34800CC887E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -459,6 +575,7 @@
 			files = (
 				D7ADFD112066CF9400B531F9 /* CoreLocation.framework in Frameworks */,
 				FCD1D177D08D9313171AB7ED /* Pods_FSNotes_iOS.framework in Frameworks */,
+				6F13BB6120FEDE560005E120 /* FSNotesCore_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -466,6 +583,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F13BB1920FEDDF50005E120 /* FSNotesCore_macOS.framework in Frameworks */,
 				93D1825473D129F6D510814D /* Pods_FSNotes.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -481,6 +599,147 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6F13BB2320FEDE230005E120 /* FSNotesCore */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB2420FEDE230005E120 /* Shared */,
+				6F13BB2E20FEDE230005E120 /* Core iOS */,
+				6F13BB3320FEDE230005E120 /* Core macOS */,
+			);
+			path = FSNotesCore;
+			sourceTree = "<group>";
+		};
+		6F13BB2420FEDE230005E120 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB2720FEDE230005E120 /* Extensions */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		6F13BB2720FEDE230005E120 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB2820FEDE230005E120 /* DateFormatter+.swift */,
+				6F13BB2920FEDE230005E120 /* String+.swift */,
+				6F13BB2A20FEDE230005E120 /* URL+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6F13BB2E20FEDE230005E120 /* Core iOS */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB2F20FEDE230005E120 /* Extensions */,
+				6F13BB3120FEDE230005E120 /* Helpers */,
+				6F13BB4E20FEDE560005E120 /* FSNotesCore_iOS.h */,
+				6F13BB4F20FEDE560005E120 /* Info.plist */,
+			);
+			path = "Core iOS";
+			sourceTree = "<group>";
+		};
+		6F13BB2F20FEDE230005E120 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6F13BB3120FEDE230005E120 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		6F13BB3320FEDE230005E120 /* Core macOS */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB3520FEDE230005E120 /* Extensions */,
+				6F13BB3720FEDE230005E120 /* Helpers */,
+				6F13BB0620FEDDF50005E120 /* FSNotesCore_macOS.h */,
+				6F13BB0720FEDDF50005E120 /* Info.plist */,
+			);
+			path = "Core macOS";
+			sourceTree = "<group>";
+		};
+		6F13BB3520FEDE230005E120 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB3620FEDE230005E120 /* NSView+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6F13BB3720FEDE230005E120 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB3820FEDE230005E120 /* UserDataService.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		6F13BB3A20FEDE330005E120 /* FSNotesCoreTests */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB3B20FEDE330005E120 /* iOSTests */,
+				6F13BB3E20FEDE330005E120 /* macOSTests */,
+				6F13BB4320FEDE330005E120 /* SharedTests */,
+			);
+			path = FSNotesCoreTests;
+			sourceTree = "<group>";
+		};
+		6F13BB3B20FEDE330005E120 /* iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB5B20FEDE560005E120 /* FSNotesCore_iOSTests.swift */,
+				6F13BB5D20FEDE560005E120 /* Info.plist */,
+			);
+			path = iOSTests;
+			sourceTree = "<group>";
+		};
+		6F13BB3E20FEDE330005E120 /* macOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB3F20FEDE330005E120 /* Extensions */,
+				6F13BB4020FEDE330005E120 /* Helpers */,
+				6F13BB1520FEDDF50005E120 /* Info.plist */,
+			);
+			path = macOSTests;
+			sourceTree = "<group>";
+		};
+		6F13BB3F20FEDE330005E120 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6F13BB4020FEDE330005E120 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB4120FEDE330005E120 /* UserDataServiceTests.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		6F13BB4320FEDE330005E120 /* SharedTests */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB4420FEDE330005E120 /* Extensions */,
+			);
+			path = SharedTests;
+			sourceTree = "<group>";
+		};
+		6F13BB4420FEDE330005E120 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6F13BB4520FEDE330005E120 /* DateFormatter+Tests.swift */,
+				6F13BB4620FEDE330005E120 /* String+Tests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		A124E2E6306B074DE002E8BA /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -578,6 +837,8 @@
 			isa = PBXGroup;
 			children = (
 				D7D61FCC1F32EEA1004357C2 /* Resources */,
+				6F13BB2320FEDE230005E120 /* FSNotesCore */,
+				6F13BB3A20FEDE330005E120 /* FSNotesCoreTests */,
 				D7793C711F211C6000CA39B7 /* FSNotes */,
 				D7679387201F21F5000F7BBF /* FSNotes iOS */,
 				D75F3337205EC34800CC887E /* FSNotes iOS Share */,
@@ -594,6 +855,10 @@
 				D7E81C5A1F925B5F00416A91 /* FSNotes.app */,
 				D7679386201F21F5000F7BBF /* FSNotes iOS.app */,
 				D75F3336205EC34800CC887E /* FSNotes iOS Share Extension.appex */,
+				6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */,
+				6F13BB0C20FEDDF50005E120 /* FSNotesCore macOSTests.xctest */,
+				6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */,
+				6F13BB5420FEDE560005E120 /* FSNotesCore iOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -646,13 +911,8 @@
 		D7CD5F6A1F51184A006AA35D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				D7475F542069245B00233126 /* DateFormatter+.swift */,
 				D7CD5F6B1F51185F006AA35D /* NSFont+.swift */,
-				6F46BBE61F55320E000D7DB2 /* String+.swift */,
 				D708AC69200288FC00A1760F /* NSTextStorage+.swift */,
-				D76025C2204F2820000B9F59 /* UIFont+.swift */,
-				D7ADFD0D2064143D00B531F9 /* URL+.swift */,
-				D7CB990A207E9F3500037E91 /* NSView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -725,7 +985,6 @@
 				D773DE7F1F36F45900A39C9F /* SandboxBookmark.swift */,
 				D76025B1204EEF64000B9F59 /* TextFormatter.swift */,
 				D76447DB1F3A4F0700965F01 /* UserDefaultsManagement.swift */,
-				D72A19982020AB940025CF5B /* UserDataService.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -746,6 +1005,7 @@
 			isa = PBXGroup;
 			children = (
 				D714496120C72D3400D7AD46 /* UIImage+Alpha.swift */,
+				D76025C2204F2820000B9F59 /* UIFont+.swift */,
 				D7CA2DA620C9B6EF00717769 /* NSMutableAttributedString+Font.swift */,
 			);
 			path = Extensions;
@@ -766,7 +1026,101 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		6F13BAFF20FEDDF40005E120 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB1620FEDDF50005E120 /* FSNotesCore_macOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB4720FEDE550005E120 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		6F13BB0320FEDDF40005E120 /* FSNotesCore macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F13BB2020FEDDF50005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore macOS" */;
+			buildPhases = (
+				6F13BAFF20FEDDF40005E120 /* Headers */,
+				6F13BB0020FEDDF40005E120 /* Sources */,
+				6F13BB0120FEDDF40005E120 /* Frameworks */,
+				6F13BB0220FEDDF40005E120 /* Resources */,
+				6F13BB7720FEE3500005E120 /* SwiftLint */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FSNotesCore macOS";
+			productName = "FSNotesCore macOS";
+			productReference = 6F13BB0420FEDDF40005E120 /* FSNotesCore_macOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6F13BB0B20FEDDF50005E120 /* FSNotesCore macOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F13BB2120FEDDF50005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore macOSTests" */;
+			buildPhases = (
+				6F13BB0820FEDDF50005E120 /* Sources */,
+				6F13BB0920FEDDF50005E120 /* Frameworks */,
+				6F13BB0A20FEDDF50005E120 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6F13BB0F20FEDDF50005E120 /* PBXTargetDependency */,
+				6F13BB1120FEDDF50005E120 /* PBXTargetDependency */,
+			);
+			name = "FSNotesCore macOSTests";
+			productName = "FSNotesCore macOSTests";
+			productReference = 6F13BB0C20FEDDF50005E120 /* FSNotesCore macOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6F13BB4B20FEDE550005E120 /* FSNotesCore iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F13BB6320FEDE560005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore iOS" */;
+			buildPhases = (
+				6F13BB4720FEDE550005E120 /* Headers */,
+				6F13BB4820FEDE550005E120 /* Sources */,
+				6F13BB4920FEDE550005E120 /* Frameworks */,
+				6F13BB4A20FEDE550005E120 /* Resources */,
+				6F13BB7820FEE39E0005E120 /* SwiftLint */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FSNotesCore iOS";
+			productName = "FSNotesCore iOS";
+			productReference = 6F13BB4C20FEDE550005E120 /* FSNotesCore_iOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6F13BB5320FEDE560005E120 /* FSNotesCore iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6F13BB6720FEDE560005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore iOSTests" */;
+			buildPhases = (
+				6F13BB5020FEDE560005E120 /* Sources */,
+				6F13BB5120FEDE560005E120 /* Frameworks */,
+				6F13BB5220FEDE560005E120 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6F13BB5720FEDE560005E120 /* PBXTargetDependency */,
+				6F13BB5920FEDE560005E120 /* PBXTargetDependency */,
+			);
+			name = "FSNotesCore iOSTests";
+			productName = "FSNotesCore iOSTests";
+			productReference = 6F13BB5420FEDE560005E120 /* FSNotesCore iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D75F3335205EC34800CC887E /* FSNotes iOS Share Extension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D75F3341205EC34800CC887E /* Build configuration list for PBXNativeTarget "FSNotes iOS Share Extension" */;
@@ -796,11 +1150,13 @@
 				D713542C2042D46E00E3776F /* Embed Watch Content */,
 				D73E3DE0205D17360044FF84 /* Embed App Extensions */,
 				AF041A5C63CD8E5C48CA810D /* [CP] Copy Pods Resources */,
+				6F13BB6620FEDE560005E120 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				D75F333F205EC34800CC887E /* PBXTargetDependency */,
+				6F13BB6020FEDE560005E120 /* PBXTargetDependency */,
 			);
 			name = "FSNotes iOS";
 			productName = "FSNotes iOS";
@@ -817,10 +1173,12 @@
 				D7793C6D1F211C6000CA39B7 /* Resources */,
 				EF05BC144E24BED78E33FAB7 /* [CP] Embed Pods Frameworks */,
 				4F60631C2EB37BC65B8EDE55 /* [CP] Copy Pods Resources */,
+				6F13BB1A20FEDDF50005E120 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				6F13BB1820FEDDF50005E120 /* PBXTargetDependency */,
 			);
 			name = FSNotes;
 			productName = FSNotes;
@@ -853,10 +1211,26 @@
 		D7793C671F211C6000CA39B7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
+				LastSwiftUpdateCheck = 1000;
 				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "Oleksandr Glushchenko";
 				TargetAttributes = {
+					6F13BB0320FEDDF40005E120 = {
+						CreatedOnToolsVersion = 10.0;
+						ProvisioningStyle = Automatic;
+					};
+					6F13BB0B20FEDDF50005E120 = {
+						CreatedOnToolsVersion = 10.0;
+						ProvisioningStyle = Automatic;
+					};
+					6F13BB4B20FEDE550005E120 = {
+						CreatedOnToolsVersion = 10.0;
+						ProvisioningStyle = Automatic;
+					};
+					6F13BB5320FEDE560005E120 = {
+						CreatedOnToolsVersion = 10.0;
+						ProvisioningStyle = Automatic;
+					};
 					D75F3335205EC34800CC887E = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
@@ -945,11 +1319,43 @@
 				D7E81C2B1F925B5F00416A91 /* FSNotes (iCloud Documents) */,
 				D7679385201F21F5000F7BBF /* FSNotes iOS */,
 				D75F3335205EC34800CC887E /* FSNotes iOS Share Extension */,
+				6F13BB0320FEDDF40005E120 /* FSNotesCore macOS */,
+				6F13BB0B20FEDDF50005E120 /* FSNotesCore macOSTests */,
+				6F13BB4B20FEDE550005E120 /* FSNotesCore iOS */,
+				6F13BB5320FEDE560005E120 /* FSNotesCore iOSTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		6F13BB0220FEDDF40005E120 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB0A20FEDDF50005E120 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB4A20FEDE550005E120 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB5220FEDE560005E120 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D75F3334205EC34800CC887E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1111,6 +1517,42 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FSNotes/Pods-FSNotes-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		6F13BB7720FEE3500005E120 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelif which \"${PODS_ROOT}/SwiftLint/swiftlint\" >/dev/null; then\n    \"${PODS_ROOT}/SwiftLint/swiftlint\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		6F13BB7820FEE39E0005E120 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelif which \"${PODS_ROOT}/SwiftLint/swiftlint\" >/dev/null; then\n    \"${PODS_ROOT}/SwiftLint/swiftlint\"\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		986CD03B3906CD6B3F8B8B3E /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1248,6 +1690,48 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		6F13BB0020FEDDF40005E120 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB6C20FEE04A0005E120 /* String+.swift in Sources */,
+				6F13BB7120FEE0DD0005E120 /* UserDataService.swift in Sources */,
+				6F13BB6E20FEE04F0005E120 /* URL+.swift in Sources */,
+				6F13BB6A20FEE0450005E120 /* DateFormatter+.swift in Sources */,
+				6F13BB7020FEE0A80005E120 /* NSView+.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB0820FEDDF50005E120 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB7420FEE1E80005E120 /* String+Tests.swift in Sources */,
+				6F13BB7620FEE1F20005E120 /* UserDataServiceTests.swift in Sources */,
+				6F13BB7220FEE1E30005E120 /* DateFormatter+Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB4820FEDE550005E120 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB6D20FEE04B0005E120 /* String+.swift in Sources */,
+				6F13BB6F20FEE04F0005E120 /* URL+.swift in Sources */,
+				6F13BB6B20FEE0460005E120 /* DateFormatter+.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6F13BB5020FEDE560005E120 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F13BB7320FEE1E40005E120 /* DateFormatter+Tests.swift in Sources */,
+				6F13BB5C20FEDE560005E120 /* FSNotesCore_iOSTests.swift in Sources */,
+				6F13BB7520FEE1E80005E120 /* String+Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D75F3332205EC34800CC887E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1261,11 +1745,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D73290BA2099F0AB0003F647 /* UndoData.swift in Sources */,
-				D7D3184A2086771000FEB5EA /* URL+.swift in Sources */,
 				D7B03AFC2085D4E5008FC097 /* SandboxBookmark.swift in Sources */,
 				D75F1DF0206D643600F70B28 /* MarkdownView.swift in Sources */,
 				D7D03BB0205C4DBA00D96A6D /* NoteAttribute.swift in Sources */,
-				D76025C4204F2849000B9F59 /* UIFont+.swift in Sources */,
 				D7E6D9D320808623003ECAFC /* SidebarItem.swift in Sources */,
 				D7D03BAF205C250500D96A6D /* FontViewController.swift in Sources */,
 				D7C803EF2046ED91005DA599 /* NSTextStorage+.swift in Sources */,
@@ -1279,7 +1761,6 @@
 				D7BDFE62201F678C00897A58 /* Note.swift in Sources */,
 				D71354042042AFC800E3776F /* SettingsViewController.swift in Sources */,
 				D7F6CFF02056AC22008C584A /* LanguageViewController.swift in Sources */,
-				D7BDFE5A201F677B00897A58 /* String+.swift in Sources */,
 				D7BDFE5D201F677B00897A58 /* UserDefaultsManagement.swift in Sources */,
 				D7E6D9D42080862F003ECAFC /* SidebarItemType.swift in Sources */,
 				D7C803EE2046DBBD005DA599 /* DefaultExtensionControllerView.swift in Sources */,
@@ -1288,10 +1769,10 @@
 				D7CA2DA720C9B6EF00717769 /* NSMutableAttributedString+Font.swift in Sources */,
 				D76025B4204EEF64000B9F59 /* TextFormatter.swift in Sources */,
 				D7BDFE60201F677B00897A58 /* NoteType.swift in Sources */,
-				D7475F572069245B00233126 /* DateFormatter+.swift in Sources */,
 				D706396A202230BB00BC8446 /* EditorViewController.swift in Sources */,
 				D7BDFE61201F677B00897A58 /* SortBy.swift in Sources */,
 				D7BDFE59201F671900897A58 /* Storage.swift in Sources */,
+				6F13BB7920FEE6070005E120 /* UIFont+.swift in Sources */,
 				D73673A820D10CF2000BA61D /* CloudDriveManager.swift in Sources */,
 				D767938B201F21F5000F7BBF /* ViewController.swift in Sources */,
 				D7679389201F21F5000F7BBF /* AppDelegate.swift in Sources */,
@@ -1306,9 +1787,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D7CB990B207E9F3500037E91 /* NSView+.swift in Sources */,
 				D7E6ACE920832D41003599A2 /* AppDelegate+URLRoutes.swift in Sources */,
-				D7475F552069245B00233126 /* DateFormatter+.swift in Sources */,
 				D7170C1D20F8565B001DDB36 /* FileSystemEventManager.swift in Sources */,
 				D779C7BB1F415C0300FADEE1 /* PrefsWindowController.swift in Sources */,
 				D7793C751F211C6000CA39B7 /* ViewController.swift in Sources */,
@@ -1343,14 +1822,11 @@
 				D7679376201F0BFD000F7BBF /* SortBy.swift in Sources */,
 				D7A415141F2FBDA00099B82C /* NotesTableView.swift in Sources */,
 				D7B024A72019BCF3008544C3 /* NoteAttribute.swift in Sources */,
-				D72A19992020AB940025CF5B /* UserDataService.swift in Sources */,
 				D773DE801F36F45900A39C9F /* SandboxBookmark.swift in Sources */,
 				D7CD5F6C1F51185F006AA35D /* NSFont+.swift in Sources */,
 				D7508FC81F337E850047AB76 /* SearchTextField.swift in Sources */,
 				275592971F3AE9B5006B8988 /* MainWindowController.swift in Sources */,
-				6F46BBE71F55320E000D7DB2 /* String+.swift in Sources */,
 				D735E5BD1F2EF66000173215 /* NoteCellView.swift in Sources */,
-				D7ADFD0E2064143D00B531F9 /* URL+.swift in Sources */,
 				D78678CB2093AE10001A6620 /* UndoData.swift in Sources */,
 				D7B3391520DE0FB100B36460 /* TagList.swift in Sources */,
 				D79FE8A21F77D04A00113CFD /* Note.swift in Sources */,
@@ -1362,12 +1838,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D7ADFD0F2064285900B531F9 /* URL+.swift in Sources */,
 				D7E6ACEA20832D41003599A2 /* AppDelegate+URLRoutes.swift in Sources */,
-				D7CB990C207E9F3500037E91 /* NSView+.swift in Sources */,
 				D7170C1E20F8565B001DDB36 /* FileSystemEventManager.swift in Sources */,
 				D777D782200912A400D86B33 /* ImagesProcessor.swift in Sources */,
-				D7475F562069245B00233126 /* DateFormatter+.swift in Sources */,
 				D708AC6B200299F600A1760F /* NSTextStorage+.swift in Sources */,
 				D708AC682000F0E100A1760F /* NoteType.swift in Sources */,
 				D790641D1FCB4E5F005677E7 /* MarkdownView.swift in Sources */,
@@ -1400,12 +1873,10 @@
 				D7E81C391F925B5F00416A91 /* FileWatcherEvent.swift in Sources */,
 				D7B024A82019BCF3008544C3 /* NoteAttribute.swift in Sources */,
 				D7E81C3A1F925B5F00416A91 /* NotesTableView.swift in Sources */,
-				D72A199A2020AB940025CF5B /* UserDataService.swift in Sources */,
 				D7E81C3D1F925B5F00416A91 /* SandboxBookmark.swift in Sources */,
 				D7E81C3F1F925B5F00416A91 /* NSFont+.swift in Sources */,
 				D7E81C411F925B5F00416A91 /* SearchTextField.swift in Sources */,
 				D7E81C421F925B5F00416A91 /* MainWindowController.swift in Sources */,
-				D7E81C431F925B5F00416A91 /* String+.swift in Sources */,
 				D7E81C441F925B5F00416A91 /* NoteCellView.swift in Sources */,
 				D78678CC2093AE10001A6620 /* UndoData.swift in Sources */,
 				D7B3391620DE0FB100B36460 /* TagList.swift in Sources */,
@@ -1417,6 +1888,36 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		6F13BB0F20FEDDF50005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6F13BB0320FEDDF40005E120 /* FSNotesCore macOS */;
+			targetProxy = 6F13BB0E20FEDDF50005E120 /* PBXContainerItemProxy */;
+		};
+		6F13BB1120FEDDF50005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D7793C6E1F211C6000CA39B7 /* FSNotes */;
+			targetProxy = 6F13BB1020FEDDF50005E120 /* PBXContainerItemProxy */;
+		};
+		6F13BB1820FEDDF50005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6F13BB0320FEDDF40005E120 /* FSNotesCore macOS */;
+			targetProxy = 6F13BB1720FEDDF50005E120 /* PBXContainerItemProxy */;
+		};
+		6F13BB5720FEDE560005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6F13BB4B20FEDE550005E120 /* FSNotesCore iOS */;
+			targetProxy = 6F13BB5620FEDE560005E120 /* PBXContainerItemProxy */;
+		};
+		6F13BB5920FEDE560005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D7679385201F21F5000F7BBF /* FSNotes iOS */;
+			targetProxy = 6F13BB5820FEDE560005E120 /* PBXContainerItemProxy */;
+		};
+		6F13BB6020FEDE560005E120 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6F13BB4B20FEDE550005E120 /* FSNotesCore iOS */;
+			targetProxy = 6F13BB5F20FEDE560005E120 /* PBXContainerItemProxy */;
+		};
 		D75F333F205EC34800CC887E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D75F3335205EC34800CC887E /* FSNotes iOS Share Extension */;
@@ -1502,6 +2003,220 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		6F13BB1C20FEDDF50005E120 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "FSNotesCore/Core macOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6F13BB1D20FEDDF50005E120 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 866P6MTE92;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "FSNotesCore/Core macOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6F13BB1E20FEDDF50005E120 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = FSNotesCoreTests/macOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-macOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		6F13BB1F20FEDDF50005E120 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				INFOPLIST_FILE = FSNotesCoreTests/macOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-macOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
+		6F13BB6420FEDE560005E120 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 866P6MTE92;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "FSNotesCore/Core iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6F13BB6520FEDE560005E120 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 866P6MTE92;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				INFOPLIST_FILE = "FSNotesCore/Core iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6F13BB6820FEDE560005E120 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = FSNotesCoreTests/iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6F13BB6920FEDE560005E120 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_NS_ASSERTIONS = NO;
+				INFOPLIST_FILE = FSNotesCoreTests/iOSTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "co.fluder.FSNotesCore-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		D75F3342205EC34800CC887E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1548,7 +2263,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AD6B2C2AB86ECC93C9C8FD65 /* Pods-FSNotes iOS.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "FSNotes iOS/FSNotes iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1573,7 +2288,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 37B79424582BB5A99620600F /* Pods-FSNotes iOS.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "FSNotes iOS/FSNotes iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
@@ -1711,10 +2426,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D4CB680A72611EC13792DED /* Pods-FSNotes.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FSNotes/FSNotes.entitlements;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
@@ -1742,6 +2458,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2F06741487033D206BD611B4 /* Pods-FSNotes.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = FSNotes/FSNotes.entitlements;
@@ -1841,6 +2558,42 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6F13BB2020FEDDF50005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F13BB1C20FEDDF50005E120 /* Debug */,
+				6F13BB1D20FEDDF50005E120 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6F13BB2120FEDDF50005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore macOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F13BB1E20FEDDF50005E120 /* Debug */,
+				6F13BB1F20FEDDF50005E120 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6F13BB6320FEDE560005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F13BB6420FEDE560005E120 /* Debug */,
+				6F13BB6520FEDE560005E120 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6F13BB6720FEDE560005E120 /* Build configuration list for PBXNativeTarget "FSNotesCore iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6F13BB6820FEDE560005E120 /* Debug */,
+				6F13BB6920FEDE560005E120 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D75F3341205EC34800CC887E /* Build configuration list for PBXNativeTarget "FSNotes iOS Share Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/FSNotes/AppDelegate.swift
+++ b/FSNotes/AppDelegate.swift
@@ -8,6 +8,8 @@
 
 import Cocoa
 
+import FSNotesCore_macOS
+
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     var mainWindowController: MainWindowController?

--- a/FSNotes/Helpers/FileSystemEventManager.swift
+++ b/FSNotes/Helpers/FileSystemEventManager.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import FSNotesCore_macOS
+
 class FileSystemEventManager {
     private var storage: Storage
     private var delegate: ViewController

--- a/FSNotes/Helpers/ImagesProcessor.swift
+++ b/FSNotes/Helpers/ImagesProcessor.swift
@@ -95,10 +95,12 @@ public class ImagesProcessor {
                 guard let imageUrl = url else { return }
                 
                 let cacheUrl = self.note.project?.url.appendingPathComponent("/.cache/")
+                #if os(OSX)
                 let imageAttachment = ImageAttachment(title: title, path: filePath, url: imageUrl, cache: cacheUrl)
                 if let attributedStringWithImage = imageAttachment.getAttributedString() {
                     self.styleApplier.replaceCharacters(in: range, with: attributedStringWithImage)
                 }
+                #endif
             }
         }
     }

--- a/FSNotes/View/NotesTableView.swift
+++ b/FSNotes/View/NotesTableView.swift
@@ -9,6 +9,8 @@
 import Carbon
 import Cocoa
 
+import FSNotesCore_macOS
+
 class NotesTableView: NSTableView, NSTableViewDataSource,
     NSTableViewDelegate {
     

--- a/FSNotes/View/SearchTextField.swift
+++ b/FSNotes/View/SearchTextField.swift
@@ -9,6 +9,8 @@
 import Cocoa
 import Carbon.HIToolbox
 
+import FSNotesCore_macOS
+
 class SearchTextField: NSTextField, NSTextFieldDelegate {
 
     public var vcDelegate: ViewController!

--- a/FSNotes/View/SidebarProjectView.swift
+++ b/FSNotes/View/SidebarProjectView.swift
@@ -10,6 +10,8 @@ import Cocoa
 import Foundation
 import Carbon.HIToolbox
 
+import FSNotesCore_macOS
+
 class SidebarProjectView: NSOutlineView, NSOutlineViewDelegate, NSOutlineViewDataSource {
     
     var sidebarItems: [SidebarItem]? = nil

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -9,6 +9,8 @@
 import Cocoa
 import MASShortcut
 
+import FSNotesCore_macOS
+
 class ViewController: NSViewController,
     NSTextViewDelegate,
     NSTextFieldDelegate,
@@ -1202,7 +1204,9 @@ class ViewController: NSViewController,
     
     @IBAction func duplicate(_ sender: Any) {
         if let note = notesTableView.getSelectedNote() {
-            note.duplicate()
+            let (url, skipReload) = note.duplicate()
+            UserDataService.instance.lastRenamed = url
+            UserDataService.instance.skipListReload = skipReload
         }
     }
     

--- a/FSNotesCore/Core iOS/FSNotesCore_iOS.h
+++ b/FSNotesCore/Core iOS/FSNotesCore_iOS.h
@@ -1,0 +1,19 @@
+//
+//  FSNotesCore_iOS.h
+//  FSNotesCore iOS
+//
+//  Created by Christopher Reimann on 7/17/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for FSNotesCore_iOS.
+FOUNDATION_EXPORT double FSNotesCore_iOSVersionNumber;
+
+//! Project version string for FSNotesCore_iOS.
+FOUNDATION_EXPORT const unsigned char FSNotesCore_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FSNotesCore_iOS/PublicHeader.h>
+
+

--- a/FSNotesCore/Core iOS/Info.plist
+++ b/FSNotesCore/Core iOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/FSNotesCore/Core macOS/Extensions/NSView+.swift
+++ b/FSNotesCore/Core macOS/Extensions/NSView+.swift
@@ -8,16 +8,15 @@
 
 import Cocoa
 
-extension NSView {
-    var viewBackgroundColor: NSColor? {
+public extension NSView {
+    public var viewBackgroundColor: NSColor? {
         get {
-            if let colorRef = self.layer?.backgroundColor {
-                return NSColor(cgColor: colorRef)
-            } else {
+            guard let colorRef = self.layer?.backgroundColor else {
                 return nil
             }
+            return NSColor(cgColor: colorRef)
         }
-        
+
         set {
             self.wantsLayer = true
             self.layer?.backgroundColor = newValue?.cgColor

--- a/FSNotesCore/Core macOS/FSNotesCore_macOS.h
+++ b/FSNotesCore/Core macOS/FSNotesCore_macOS.h
@@ -1,0 +1,19 @@
+//
+//  FSNotesCore_macOS.h
+//  FSNotesCore macOS
+//
+//  Created by Christopher Reimann on 7/17/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for FSNotesCore_macOS.
+FOUNDATION_EXPORT double FSNotesCore_macOSVersionNumber;
+
+//! Project version string for FSNotesCore_macOS.
+FOUNDATION_EXPORT const unsigned char FSNotesCore_macOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FSNotesCore_macOS/PublicHeader.h>
+
+

--- a/FSNotesCore/Core macOS/Helpers/UserDataService.swift
+++ b/FSNotesCore/Core macOS/Helpers/UserDataService.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-class UserDataService {
-    static let instance = UserDataService()
-    
+public class UserDataService {
+    public static let instance = UserDataService()
+
     fileprivate var _isShortcutCall = false
     fileprivate var _searchTrigger = false
-    fileprivate var _lastRenamed: URL? = nil
+    fileprivate var _lastRenamed: URL?
     fileprivate var _fsUpdates = false
     fileprivate var _skipListReload = false
-    
-    var isShortcutCall: Bool {
+
+    public var isShortcutCall: Bool {
         get {
             return _isShortcutCall
         }
@@ -25,8 +25,8 @@ class UserDataService {
             _isShortcutCall = newValue
         }
     }
-    
-    var searchTrigger: Bool {
+
+    public var searchTrigger: Bool {
         get {
             return _searchTrigger
         }
@@ -34,8 +34,8 @@ class UserDataService {
             _searchTrigger = newValue
         }
     }
-    
-    var lastRenamed: URL? {
+
+    public var lastRenamed: URL? {
         get {
             return _lastRenamed
         }
@@ -43,8 +43,8 @@ class UserDataService {
             _lastRenamed = newValue
         }
     }
-    
-    var fsUpdatesDisabled: Bool {
+
+    public var fsUpdatesDisabled: Bool {
         get {
             return _fsUpdates
         }
@@ -52,8 +52,8 @@ class UserDataService {
             _fsUpdates = newValue
         }
     }
-    
-    var skipListReload: Bool {
+
+    public var skipListReload: Bool {
         get {
             return _skipListReload
         }

--- a/FSNotesCore/Core macOS/Info.plist
+++ b/FSNotesCore/Core macOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2018 Oleksandr Glushchenko. All rights reserved.</string>
+</dict>
+</plist>

--- a/FSNotesCore/Shared/Extensions/DateFormatter+.swift
+++ b/FSNotesCore/Shared/Extensions/DateFormatter+.swift
@@ -8,21 +8,23 @@
 
 import Foundation
 
-
-extension DateFormatter {
-    func formatDateForDisplay(_ date: Date) -> String {
+public extension DateFormatter {
+    public func formatDateForDisplay(_ date: Date) -> String {
         dateStyle = .short
         timeStyle = .none
         locale = NSLocale.autoupdatingCurrent
         return string(from: date)
     }
-    
-    func formatTimeForDisplay(_ date: Date) -> String {
+
+    public func formatTimeForDisplay(_ date: Date) -> String {
         dateStyle = .none
         timeStyle = .short
         locale = NSLocale.autoupdatingCurrent
         return string(from: date)
     }
 
+    public func formatForDuplicate(_ date: Date) -> String {
+        dateFormat = "yyyyMMddhhmmss"
+        return string(from: date)
+    }
 }
-

--- a/FSNotesCore/Shared/Extensions/String+.swift
+++ b/FSNotesCore/Shared/Extensions/String+.swift
@@ -8,20 +8,19 @@
 
 import Foundation
 
-extension String {
-    func condenseWhitespace() -> String {
+public extension String {
+    public func condenseWhitespace() -> String {
         let components = self.components(separatedBy: NSCharacterSet.whitespacesAndNewlines)
         return components.filter { !$0.isEmpty }.joined(separator: " ")
     }
 
-    // Search the string for the existence of any of the terms in the
-    // provided array of terms.
-    func localizedCaseInsensitiveContainsTerms(_ terms: [Substring]) -> Bool {        
-        // Use magic from https://stackoverflow.com/a/41902740/2778502
-        return terms.first(where: { !self.localizedLowercase.contains($0) }) == nil
+    // Search the string for the existence of any of the terms in the provided array of terms.
+    // Inspired by magic from https://stackoverflow.com/a/41902740/2778502
+    public func localizedStandardContains<S: StringProtocol>(_ terms: [S]) -> Bool {
+        return terms.first(where: { self.localizedStandardContains($0) }) != nil
     }
-    
-    func trim() -> String {
+
+    public func trim() -> String {
         return self.trimmingCharacters(in: NSCharacterSet.whitespaces)
     }
     

--- a/FSNotesCore/Shared/Extensions/URL+.swift
+++ b/FSNotesCore/Shared/Extensions/URL+.swift
@@ -8,21 +8,19 @@
 
 import Foundation
 
-extension URL {
-    
+public extension URL {
     /// Get extended attribute.
-    func extendedAttribute(forName name: String) throws -> Data  {
-        
-        let data = try self.withUnsafeFileSystemRepresentation { fileSystemPath -> Data in
-            
+    public func extendedAttribute(forName name: String) throws -> Data {
+        return try self.withUnsafeFileSystemRepresentation { fileSystemPath -> Data in
+
             // Determine attribute size:
             let length = getxattr(fileSystemPath, name, nil, 0, 0, 0)
             guard length >= 0 else { throw URL.posixError(errno) }
-            
+
             // Create buffer with required size:
             var data = Data(count: length)
             let count = data.count
-            
+
             // Retrieve attribute:
             let result = data.withUnsafeMutableBytes {
                 getxattr(fileSystemPath, name, $0, count, 0, 0)
@@ -30,68 +28,66 @@ extension URL {
             guard result >= 0 else { throw URL.posixError(errno) }
             return data
         }
-        return data
     }
-    
+
     /// Set extended attribute.
-    func setExtendedAttribute(data: Data, forName name: String) throws {
-        
+    public func setExtendedAttribute(data: Data, forName name: String) throws {
+
         try self.withUnsafeFileSystemRepresentation { fileSystemPath in
             let result = data.withUnsafeBytes {
                 setxattr(fileSystemPath, name, $0, data.count, 0, 0)
             }
-            guard result >= 0 else { throw URL.posixError(errno) }
+            guard result == 0 else { throw URL.posixError(errno) }
         }
     }
-    
+
     /// Remove extended attribute.
-    func removeExtendedAttribute(forName name: String) throws {
-        
+    public func removeExtendedAttribute(forName name: String) throws {
+
         try self.withUnsafeFileSystemRepresentation { fileSystemPath in
             let result = removexattr(fileSystemPath, name, 0)
-            guard result >= 0 else { throw URL.posixError(errno) }
+            guard result == 0 else { throw URL.posixError(errno) }
         }
     }
-    
+
     /// Get list of all extended attributes.
-    func listExtendedAttributes() throws -> [String] {
-        
-        let list = try self.withUnsafeFileSystemRepresentation { fileSystemPath -> [String] in
+    public func listExtendedAttributes() throws -> [String] {
+
+        return try self.withUnsafeFileSystemRepresentation { fileSystemPath -> [String] in
             let length = listxattr(fileSystemPath, nil, 0, 0)
             guard length >= 0 else { throw URL.posixError(errno) }
-            
+
             // Create buffer with required size:
             var data = Data(count: length)
             let count = data.count
-            
+
             // Retrieve attribute list:
             let result = data.withUnsafeMutableBytes {
                 listxattr(fileSystemPath, $0, count, 0)
             }
             guard result >= 0 else { throw URL.posixError(errno) }
-            
+
             // Extract attribute names:
-            let list = data.split(separator: 0).flatMap {
+            let list = data.split(separator: 0).compactMap {
                 String(data: Data($0), encoding: .utf8)
             }
             return list
         }
-        return list
     }
-    
+
     /// Helper function to create an NSError from a Unix errno.
     private static func posixError(_ err: Int32) -> NSError {
         return NSError(domain: NSPOSIXErrorDomain, code: Int(err),
                        userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(err))])
     }
-    
+
     // Access the URL parameters eg nv://make?title=blah&txt=body like so:
     // let titleStr = myURL['title']
-    subscript(queryParam:String) -> String? {
+    public subscript(queryParam: String) -> String? {
         guard let url = URLComponents(string: self.absoluteString) else { return nil }
         return url.queryItems?.first(where: { $0.name == queryParam })?.value
     }
-    
+
     public func isRemote() -> Bool {
         return (self.absoluteString.starts(with: "http://") || self.absoluteString.starts(with: "https://"))
     }

--- a/FSNotesCoreTests/SharedTests/Extensions/DateFormatter+Tests.swift
+++ b/FSNotesCoreTests/SharedTests/Extensions/DateFormatter+Tests.swift
@@ -1,0 +1,53 @@
+//
+//  DateFormatter+Tests.swift
+//  FSNotes
+//
+//  Created by Christopher Reimann on 7/14/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import XCTest
+#if os(OSX)
+@testable import FSNotesCore_macOS
+#elseif os(iOS)
+@testable import FSNotesCore_iOS
+#endif
+
+class DateFormatterExtensionTests: XCTestCase {
+    let secondsFromGMT = NSLocale.autoupdatingCurrent.calendar.timeZone.secondsFromGMT()
+    var formatter: DateFormatter!
+
+    override func setUp() {
+        formatter = DateFormatter()
+    }
+
+    func testFormatDateForDisplay() {
+        let date = Date(timeIntervalSinceReferenceDate: 0)
+        let df = DateFormatter()
+        df.locale = NSLocale.autoupdatingCurrent
+        df.dateStyle = .short
+        df.timeStyle = .none
+
+        XCTAssertEqual(formatter.formatDateForDisplay(date), df.string(from: date))
+    }
+
+    func testFormatTimeForDisplay() {
+        let date = Date(timeIntervalSinceReferenceDate: 0)
+        let df = DateFormatter()
+        df.locale = NSLocale.autoupdatingCurrent
+        df.dateStyle = .none
+        df.timeStyle = .short
+
+        XCTAssertEqual(formatter.formatTimeForDisplay(date), df.string(from: date))
+    }
+
+    func testformatForDuplicate() {
+        let date = Date(timeIntervalSinceReferenceDate: 0)
+        let df = DateFormatter()
+        df.locale = NSLocale.autoupdatingCurrent
+        df.dateFormat = "yyyyMMddhhmmss"
+
+        XCTAssertEqual(formatter.formatForDuplicate(date), df.string(from: date))
+
+    }
+}

--- a/FSNotesCoreTests/SharedTests/Extensions/String+Tests.swift
+++ b/FSNotesCoreTests/SharedTests/Extensions/String+Tests.swift
@@ -1,0 +1,37 @@
+//
+//  String+.swift
+//  FSNotes
+//
+//  Created by Christopher Reimann on 7/14/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import XCTest
+#if os(OSX)
+@testable import FSNotesCore_macOS
+#elseif os(iOS)
+@testable import FSNotesCore_iOS
+#endif
+
+class StringExtensionTests: XCTestCase {
+
+    func testCondenseWhitespace() {
+        XCTAssertEqual("  \nhello world\n\nwhat's up\n".condenseWhitespace(), "hello world what's up")
+    }
+
+    func testLocalizedStandardContains() {
+        XCTAssertTrue(
+            "hello world".localizedStandardContains("hello world".split(separator: " "))
+        )
+        XCTAssertTrue(
+            "hello world".localizedStandardContains(["world"])
+        )
+        XCTAssertFalse(
+            "hello world".localizedStandardContains("goodbye all".split(separator: " "))
+        )
+    }
+
+    func testTrim() {
+        XCTAssertEqual("  \n  \nhello world\n\n    ".trim(), "\n  \nhello world\n\n")
+    }
+}

--- a/FSNotesCoreTests/iOSTests/FSNotesCore_iOSTests.swift
+++ b/FSNotesCoreTests/iOSTests/FSNotesCore_iOSTests.swift
@@ -1,0 +1,36 @@
+//
+//  FSNotesCore_iOSTests.swift
+//  FSNotesCore iOSTests
+//
+//  Created by Christopher Reimann on 7/17/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import XCTest
+@testable import FSNotesCore_iOS
+
+class FSNotesCore_iOSTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/FSNotesCoreTests/iOSTests/Info.plist
+++ b/FSNotesCoreTests/iOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/FSNotesCoreTests/macOSTests/Helpers/UserDataServiceTests.swift
+++ b/FSNotesCoreTests/macOSTests/Helpers/UserDataServiceTests.swift
@@ -1,0 +1,74 @@
+//
+//  File.swift
+//  FSNotes
+//
+//  Created by Christopher Reimann on 7/14/18.
+//  Copyright © 2018 Oleksandr Glushchenko. All rights reserved.
+//
+
+import XCTest
+@testable import FSNotesCore_macOS
+
+class UserDataServiceTests: XCTestCase {
+
+    var service: UserDataService!
+
+    override func setUp() {
+        super.setUp()
+        service = UserDataService()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testIsShortcutCall() {
+        XCTAssertFalse(service.isShortcutCall)
+
+        service.isShortcutCall = true
+        XCTAssertTrue(service.isShortcutCall)
+
+        service.isShortcutCall = false
+        XCTAssertFalse(service.isShortcutCall)
+    }
+
+    func testSearchTrigger() {
+        XCTAssertFalse(service.searchTrigger)
+
+        service.searchTrigger = true
+        XCTAssertTrue(service.searchTrigger)
+
+        service.searchTrigger = false
+        XCTAssertFalse(service.searchTrigger)
+    }
+
+    func testLastRenamed() {
+        XCTAssert(service.lastRenamed == nil)
+
+        service.lastRenamed = URL(string: "file:///tmp/foo")
+        XCTAssertEqual(service.lastRenamed?.absoluteString, URL(string: "file:///tmp/foo")?.absoluteString)
+
+        service.lastRenamed = nil
+        XCTAssertNil(service.lastRenamed)
+    }
+
+    func testFsUpdatesDisabled() {
+        XCTAssertFalse(service.fsUpdatesDisabled)
+
+        service.fsUpdatesDisabled = true
+        XCTAssertTrue(service.fsUpdatesDisabled)
+
+        service.fsUpdatesDisabled = false
+        XCTAssertFalse(service.fsUpdatesDisabled)
+    }
+
+    func testSkipListReload() {
+        XCTAssertFalse(service.skipListReload)
+
+        service.skipListReload = true
+        XCTAssertTrue(service.skipListReload)
+
+        service.skipListReload = false
+        XCTAssertFalse(service.skipListReload)
+    }
+}

--- a/FSNotesCoreTests/macOSTests/Info.plist
+++ b/FSNotesCoreTests/macOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -12,6 +12,20 @@ def common_pods
     pod 'Down', '~> 0.5.2'
 end
 
+def framework_pods
+    pod 'SwiftLint', '~> 0.26.0'
+end
+
+target 'FSNotesCore_iOS' do
+    platform :ios, IOS_TARGET_VERSION
+    framework_pods
+end
+
+target 'FSNotesCore_macOS' do
+    platform :osx, MAC_TARGET_VERSION
+    framework_pods
+end
+
 target 'FSNotes' do
     platform :osx, MAC_TARGET_VERSION
 


### PR DESCRIPTION
There appears to be a lot of code that is shared between the Mac and iOS apps, however it is littered with conditional compilation and appears to be prone to leaky abstractions. This is my stab at moving shared code out into frameworks that are embedded into their respective applications.

During this process I'm adding as many tests unit tests as I can because I see there aren't any tests in this project yet.