### PR TITLE
fix notes table appearance in dark mode

### DIFF
--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -25,8 +25,16 @@ class ViewController: NSViewController,
     @IBOutlet weak var searchWrapper: NSTextField!
     @IBOutlet var editArea: EditTextView!
     @IBOutlet weak var editAreaScroll: NSScrollView!
-    @IBOutlet weak var search: SearchTextField!
-    @IBOutlet weak var notesTableView: NotesTableView!
+    @IBOutlet weak var search: SearchTextField! {
+        didSet {
+            search.appearance = NSAppearance.init(named: .aqua)
+        }
+    }
+    @IBOutlet weak var notesTableView: NotesTableView! {
+        didSet {
+            notesTableView.appearance = NSAppearance.init(named: .aqua)
+        }
+    }
     @IBOutlet var noteMenu: NSMenu!
     @IBOutlet weak var storageOutlineView: SidebarProjectView!
     @IBOutlet weak var sidebarSplitView: NSSplitView!


### PR DESCRIPTION
before:
![before](https://duaw26jehqd4r.cloudfront.net/items/243f0m2W3I0z3k1V0m2Q/Screen%20Shot%202018-10-18%20at%2022.53.16.png?v=5731f55b)

after:
![after](
https://duaw26jehqd4r.cloudfront.net/items/0C3O0x3E0W3G1L1K2s0f/Screen%20Shot%202018-10-18%20at%2023.36.15.png?v=feaad263)

I was thinking about such mode:
![dark notes table](
https://duaw26jehqd4r.cloudfront.net/items/2m1c1h0k0c1u2D0I1H3X/Screen%20Shot%202018-10-18%20at%2022.48.15.png?v=11f42dcd)