### PR TITLE
Move renaming field to title in editor view

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1522,13 +1522,16 @@ CA
                                                             <autoresizingMask key="autoresizingMask"/>
                                                         </scroller>
                                                     </scrollView>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ">
-                                                        <rect key="frame" x="0.0" y="563" width="417" height="20"/>
+                                                    <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ">
+                                                        <rect key="frame" x="191" y="573" width="35" height="17"/>
                                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
                                                             <font key="font" size="13" name=".AppleSystemUIFont"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="mainBackground"/>
                                                         </textFieldCell>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="XfG-lQ-9wD" id="ikK-Ty-iHC"/>
+                                                        </connections>
                                                     </textField>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDB-Y6-20P">
                                                         <rect key="frame" x="368" y="564" width="47" height="32"/>
@@ -1548,15 +1551,16 @@ CA
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
+                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rZx-hk-GcJ" secondAttribute="trailing" constant="70" id="3VI-a3-aJP"/>
                                                     <constraint firstAttribute="trailing" secondItem="oDB-Y6-20P" secondAttribute="trailing" constant="8" id="4Tt-fb-GfO"/>
                                                     <constraint firstAttribute="trailing" secondItem="qJO-7f-vkL" secondAttribute="trailing" id="GZ2-jz-8Ue"/>
-                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="QX8-11-49c"/>
                                                     <constraint firstItem="rZx-hk-GcJ" firstAttribute="top" secondItem="at7-wA-VAS" secondAttribute="top" constant="10" id="ZXL-jc-Tfr"/>
+                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="at7-wA-VAS" secondAttribute="leading" constant="70" id="aDP-f9-ims"/>
                                                     <constraint firstItem="oDB-Y6-20P" firstAttribute="top" secondItem="at7-wA-VAS" secondAttribute="top" constant="8" id="aPg-OL-8Mj"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="top" secondItem="rZx-hk-GcJ" secondAttribute="bottom" constant="11" id="eAG-eB-pQr"/>
                                                     <constraint firstAttribute="bottom" secondItem="qJO-7f-vkL" secondAttribute="bottom" id="hij-XA-hAd"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="inr-29-Y1D"/>
-                                                    <constraint firstAttribute="trailing" secondItem="rZx-hk-GcJ" secondAttribute="trailing" id="kLx-Os-kkP"/>
+                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerX" secondItem="at7-wA-VAS" secondAttribute="centerX" id="r1w-sy-Ky6"/>
                                                 </constraints>
                                             </customView>
                                         </subviews>

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -434,6 +434,13 @@ class ViewController: NSViewController,
                 return true
             }
 
+            // Renaming is in progress
+            if titleLabel.isEditable == true {
+                titleLabel.isEditable = false
+                titleLabel.window?.makeFirstResponder(nil)
+                return true
+            }
+            
             notesTableView.scroll(.zero)
             
             let hasSelectedNotes = notesTableView.selectedRow > -1
@@ -473,7 +480,8 @@ class ViewController: NSViewController,
             && event.modifierFlags.contains(.command)
             && !event.modifierFlags.contains(.shift)
         ) {
-            renameNote(selectedRow: notesTableView.selectedRow)
+            titleLabel.isEditable = true
+            titleLabel.becomeFirstResponder()
             return true
         }
         
@@ -866,6 +874,20 @@ class ViewController: NSViewController,
         operation.printPanel.options.insert(NSPrintPanel.Options.showsPaperSize)
         operation.printPanel.options.insert(NSPrintPanel.Options.showsOrientation)
         operation.run()
+    }
+    
+    
+    override func controlTextDidEndEditing(_ obj: Notification) {
+        guard let textField = obj.object as? NSTextField, textField == titleLabel else { return }
+        
+        if titleLabel.isEditable == true {
+            titleLabel.isEditable = false
+            fileName(titleLabel)
+        }
+        else {
+            let currentNote = notesTableView.getSelectedNote()
+            titleLabel.stringValue = currentNote?.getTitleWithoutLabel() ?? NSLocalizedString("Untitled Note", comment: "Untitled Note")
+        }
     }
     
     // Changed main edit view


### PR DESCRIPTION
Some improvements in renaming behavior. 
Now after `CMD+R` the title text field becomes editable and active.
But in case if you choose `Rename` from note cell's menu its title will become editable (as it was before)

![notes table is visible](
https://duaw26jehqd4r.cloudfront.net/items/2E2K0K2V1G1z3j2N1D0q/Screen%20Shot%202018-10-25%20at%2011.09.57.png?v=10f49872)

![notes table is hidden](
https://duaw26jehqd4r.cloudfront.net/items/1U1J0S290d1N262G1S3M/Screen%20Shot%202018-10-25%20at%2011.11.48.png?v=53f5f9e8)