### PR TITLE
fix layout constraints for the title label

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1523,8 +1523,8 @@ CA
                                                         </scroller>
                                                     </scrollView>
                                                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ">
-                                                        <rect key="frame" x="191" y="580" width="35" height="17"/>
-                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
+                                                        <rect key="frame" x="70" y="580" width="277" height="17"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
                                                             <font key="font" size="13" name=".AppleSystemUIFont"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="mainBackground"/>
@@ -1598,6 +1598,8 @@ CA
                                                 <constraints>
                                                     <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerX" secondItem="at7-wA-VAS" secondAttribute="centerX" id="1uj-pH-by2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="8Ne-do-Q9o"/>
+                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" constant="70" id="9Sl-l7-wNT"/>
+                                                    <constraint firstAttribute="trailing" secondItem="rZx-hk-GcJ" secondAttribute="trailing" constant="70" id="Ai3-Ih-AZU"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="CQ0-DY-aM0"/>
                                                     <constraint firstAttribute="trailing" secondItem="qJO-7f-vkL" secondAttribute="trailing" id="GZ2-jz-8Ue"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="top" secondItem="at7-wA-VAS" secondAttribute="top" id="Nm9-X5-Q67"/>


### PR DESCRIPTION
an issue appeared after my last resolving conflicts in the storyboard. And as the result, the title was disappearing when you switch to renaming mode. So I fixed layout constraints for the title label and set its line break to `Truncate Tail` instead of `Word Wrap`

![](
https://duaw26jehqd4r.cloudfront.net/items/153H0F2x2A1l271y3035/Screen%20Shot%202018-10-29%20at%2001.21.17.png?v=7a4dd3e9)

![](
https://duaw26jehqd4r.cloudfront.net/items/1q2a003E3c270Q1A2L3V/Screen%20Shot%202018-10-29%20at%2001.28.00.png?v=63be358d)