### PR TITLE
Switch title to edit mode by double-clicking on it

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1556,23 +1556,6 @@ CA
                                                             <autoresizingMask key="autoresizingMask"/>
                                                         </scroller>
                                                     </scrollView>
-                                                    <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ">
-                                                        <rect key="frame" x="70" y="573" width="277" height="17"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
-                                                            <font key="font" size="13" name=".AppleSystemUIFont"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="mainBackground"/>
-                                                        </textFieldCell>
-                                                        <connections>
-                                                            <outlet property="delegate" destination="XfG-lQ-9wD" id="ikK-Ty-iHC"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" alphaValue="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="Gz4-4G-Fts">
-                                                        <rect key="frame" x="179" y="254" width="59" height="91"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="makeNoteAsset" id="WpA-pT-SDs"/>
-                                                        <color key="contentTintColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                    </imageView>
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="xSU-Mk-2F1" customClass="TitleBarView" customModule="FSNotes" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="562" width="417" height="38"/>
                                                         <subviews>
@@ -1629,6 +1612,23 @@ CA
                                                             <constraint firstAttribute="height" constant="38" id="uht-o4-cfz"/>
                                                         </constraints>
                                                     </customView>
+                                                    <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ">
+                                                        <rect key="frame" x="70" y="573" width="277" height="17"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
+                                                            <font key="font" size="13" name=".AppleSystemUIFont"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="mainBackground"/>
+                                                        </textFieldCell>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="XfG-lQ-9wD" id="ikK-Ty-iHC"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" alphaValue="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="Gz4-4G-Fts">
+                                                        <rect key="frame" x="179" y="254" width="59" height="91"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="makeNoteAsset" id="WpA-pT-SDs"/>
+                                                        <color key="contentTintColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                    </imageView>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerX" secondItem="at7-wA-VAS" secondAttribute="centerX" id="1uj-pH-by2"/>

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -43,7 +43,17 @@ class ViewController: NSViewController,
     @IBOutlet weak var sidebarSplitView: NSSplitView!
     @IBOutlet weak var notesListCustomView: NSView!
     @IBOutlet weak var searchTopConstraint: NSLayoutConstraint!
-    @IBOutlet weak var titleLabel: NSTextField!
+    @IBOutlet weak var titleLabel: NSTextField! {
+        didSet {
+            let clickGesture = NSClickGestureRecognizer()
+            clickGesture.target = self
+            clickGesture.numberOfClicksRequired = 2
+            clickGesture.buttonMask = 0x1
+            clickGesture.action = #selector(switchTitleToEditMode)
+            
+            titleLabel.addGestureRecognizer(clickGesture)
+        }
+    }
     @IBOutlet weak var shareButton: NSButton!
     @IBOutlet weak var sortByOutlet: NSMenuItem!
     @IBOutlet weak var titleBarAdditionalView: NSView!
@@ -703,6 +713,10 @@ class ViewController: NSViewController,
     }
     
     @IBAction func renameMenu(_ sender: Any) {
+        switchTitleToEditMode()
+    }
+    
+    @objc func switchTitleToEditMode() {
         guard let vc = NSApp.windows[0].contentViewController as? ViewController else { return }
 
         if vc.notesTableView.selectedRow > -1 {
@@ -710,7 +724,7 @@ class ViewController: NSViewController,
             vc.titleLabel.becomeFirstResponder()
         }
     }
-        
+
     @IBAction func deleteNote(_ sender: Any) {
         guard let vc = NSApp.windows[0].contentViewController as? ViewController else { return }
         guard let notes = vc.notesTableView.getSelectedNotes() else {


### PR DESCRIPTION
Added a click gesture recognizer to the title label. So now it can be switched to edit mode just by double-clicking on it.

For reviewers:
The change in the storyboard is just moving the title label above the hidable title bar view.