### PR TITLE
Use libcmark_gfm rather than cmark-gfm-swift

### DIFF
--- a/FSNotes iOS/EditorViewController.swift
+++ b/FSNotes iOS/EditorViewController.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 import NightNight
-import Down
 import AudioToolbox
 import DKImagePickerController
 import MobileCoreServices

--- a/FSNotes iOS/View/NotesTableView.swift
+++ b/FSNotes iOS/View/NotesTableView.swift
@@ -10,7 +10,6 @@ import UIKit
 import NightNight
 import MobileCoreServices
 import AudioToolbox
-import cmark_gfm_swift
 
 class NotesTableView: UITableView,
     UITableViewDelegate,
@@ -394,7 +393,7 @@ class NotesTableView: UITableView,
 
         var string = note.content.string
         if isHTML {
-            string = Node(markdown: note.content.unLoadImages().string)!.html
+            string = renderMarkdownHTML(markdown:  note.content.unLoadImages().string)!
         }
 
         let objectsToShare = [string] as [Any]

--- a/FSNotes.xcodeproj/project.pbxproj
+++ b/FSNotes.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		6F13BB7520FEE1E80005E120 /* String+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4620FEDE330005E120 /* String+Tests.swift */; };
 		6F13BB7620FEE1F20005E120 /* UserDataServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F13BB4120FEDE330005E120 /* UserDataServiceTests.swift */; };
 		6F13BB7920FEE6070005E120 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76025C2204F2820000B9F59 /* UIFont+.swift */; };
+		8F7136EE23490CBF004DFA6E /* Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7136ED23490CBF004DFA6E /* Markdown.swift */; };
+		8F7136EF23490CBF004DFA6E /* Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7136ED23490CBF004DFA6E /* Markdown.swift */; };
+		8F7136F023490CBF004DFA6E /* Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7136ED23490CBF004DFA6E /* Markdown.swift */; };
 		AE29821E4750B1E65B616E40 /* Pods_FSNotesCore_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B22A82E1B99B4D5148437393 /* Pods_FSNotesCore_macOS.framework */; };
 		D70255FC23326130003857AF /* codeblock.png in Resources */ = {isa = PBXBuildFile; fileRef = D7C690CF22AB025700BFBBD1 /* codeblock.png */; };
 		D70255FD23326130003857AF /* codeblock.png in Resources */ = {isa = PBXBuildFile; fileRef = D7C690CF22AB025700BFBBD1 /* codeblock.png */; };
@@ -1016,6 +1019,7 @@
 		71B0A68A246DC33E2BCB2CD8 /* Pods-FSNotes iOS Share Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes iOS Share Extension.release.xcconfig"; path = "Target Support Files/Pods-FSNotes iOS Share Extension/Pods-FSNotes iOS Share Extension.release.xcconfig"; sourceTree = "<group>"; };
 		85EA5F6B493A8464ECD14B81 /* Pods-FSNotes iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes iOS.debug.xcconfig"; path = "Target Support Files/Pods-FSNotes iOS/Pods-FSNotes iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8F2EBC009F0240F232497C56 /* Pods_FSNotes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FSNotes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F7136ED23490CBF004DFA6E /* Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Markdown.swift; sourceTree = "<group>"; };
 		932F95B6D89E83ED68221FE6 /* Pods-FSNotes (Notarized).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotes (Notarized).debug.xcconfig"; path = "Target Support Files/Pods-FSNotes (Notarized)/Pods-FSNotes (Notarized).debug.xcconfig"; sourceTree = "<group>"; };
 		9AA6F8CCDEB90F200DCC9790 /* Pods-FSNotesCore macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FSNotesCore macOS.debug.xcconfig"; path = "Target Support Files/Pods-FSNotesCore macOS/Pods-FSNotesCore macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		A1FD62BB4BA133434B92CAFA /* Pods_FSNotes_iOS_Share_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FSNotes_iOS_Share_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1914,6 +1918,7 @@
 				D7A65C5820F11C38003E5ADC /* LanguageType.swift */,
 				D7CDE9DB2161767A00DC5978 /* AppearanceType.swift */,
 				D7A41C9A2316A8BE00DAAFEB /* CodeBlock.swift */,
+				8F7136ED23490CBF004DFA6E /* Markdown.swift */,
 			);
 			path = Business;
 			sourceTree = "<group>";
@@ -3015,20 +3020,18 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FSNotes/Pods-FSNotes-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MASShortcut/MASShortcut.framework",
-				"${BUILT_PRODUCTS_DIR}/Down-macOS/Down.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr-macOS/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/RNCryptor-macOS/RNCryptor.framework",
 				"${BUILT_PRODUCTS_DIR}/SSZipArchive-macOS/SSZipArchive.framework",
-				"${BUILT_PRODUCTS_DIR}/cmark-gfm-swift-macOS/cmark_gfm_swift.framework",
+				"${BUILT_PRODUCTS_DIR}/libcmark_gfm-macOS/libcmark_gfm.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MASShortcut.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Down.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNCryptor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/cmark_gfm_swift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libcmark_gfm.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3043,20 +3046,18 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FSNotes (Notarized)/Pods-FSNotes (Notarized)-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MASShortcut/MASShortcut.framework",
-				"${BUILT_PRODUCTS_DIR}/Down-macOS/Down.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr-macOS/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/RNCryptor-macOS/RNCryptor.framework",
 				"${BUILT_PRODUCTS_DIR}/SSZipArchive-macOS/SSZipArchive.framework",
-				"${BUILT_PRODUCTS_DIR}/cmark-gfm-swift-macOS/cmark_gfm_swift.framework",
+				"${BUILT_PRODUCTS_DIR}/libcmark_gfm-macOS/libcmark_gfm.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MASShortcut.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Down.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNCryptor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/cmark_gfm_swift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libcmark_gfm.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3115,20 +3116,18 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FSNotes (iCloud Documents)/Pods-FSNotes (iCloud Documents)-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MASShortcut/MASShortcut.framework",
-				"${BUILT_PRODUCTS_DIR}/Down-macOS/Down.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr-macOS/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/RNCryptor-macOS/RNCryptor.framework",
 				"${BUILT_PRODUCTS_DIR}/SSZipArchive-macOS/SSZipArchive.framework",
-				"${BUILT_PRODUCTS_DIR}/cmark-gfm-swift-macOS/cmark_gfm_swift.framework",
+				"${BUILT_PRODUCTS_DIR}/libcmark_gfm-macOS/libcmark_gfm.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MASShortcut.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Down.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNCryptor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/cmark_gfm_swift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libcmark_gfm.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3165,33 +3164,33 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FSNotes iOS/Pods-FSNotes iOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/NightNight/NightNight.framework",
-				"${BUILT_PRODUCTS_DIR}/Down-iOS/Down.framework",
 				"${BUILT_PRODUCTS_DIR}/Highlightr-iOS/Highlightr.framework",
 				"${BUILT_PRODUCTS_DIR}/RNCryptor-iOS/RNCryptor.framework",
 				"${BUILT_PRODUCTS_DIR}/SSZipArchive-iOS/SSZipArchive.framework",
-				"${BUILT_PRODUCTS_DIR}/cmark-gfm-swift-iOS/cmark_gfm_swift.framework",
+				"${BUILT_PRODUCTS_DIR}/libcmark_gfm-iOS/libcmark_gfm.framework",
 				"${BUILT_PRODUCTS_DIR}/CropViewController/CropViewController.framework",
 				"${BUILT_PRODUCTS_DIR}/DKCamera/DKCamera.framework",
 				"${BUILT_PRODUCTS_DIR}/DKImagePickerController/DKImagePickerController.framework",
 				"${BUILT_PRODUCTS_DIR}/DKPhotoGallery/DKPhotoGallery.framework",
 				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImageFLPlugin/SDWebImageFLPlugin.framework",
 				"${BUILT_PRODUCTS_DIR}/Kanna/Kanna.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NightNight.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Down.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNCryptor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/cmark_gfm_swift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/libcmark_gfm.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CropViewController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKCamera.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKImagePickerController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKPhotoGallery.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageFLPlugin.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kanna.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3367,6 +3366,7 @@
 				D7153DFF2285A93300A2C20F /* AboutWindowController.swift in Sources */,
 				D7CA7FCC2326519E00E9717A /* Git.swift in Sources */,
 				D75E33B322462442006AD1C1 /* EditorScrollView.swift in Sources */,
+				8F7136EF23490CBF004DFA6E /* Markdown.swift in Sources */,
 				D75E33B422462442006AD1C1 /* SandboxBookmark.swift in Sources */,
 				D75E33B622462442006AD1C1 /* NameHelper.swift in Sources */,
 				D75E33B722462442006AD1C1 /* PreferencesAdvancedViewController.swift in Sources */,
@@ -3436,6 +3436,7 @@
 			files = (
 				D7409FA5221DB91B0057C072 /* NSMutableAttributedString+Checkboxes.swift in Sources */,
 				D73FAE9F21553CAA0058BE61 /* UIApplication+.swift in Sources */,
+				8F7136F023490CBF004DFA6E /* Markdown.swift in Sources */,
 				D7DA9E2321033834001CF0BE /* NSMutableAttributedString+.swift in Sources */,
 				D71FD21F2101B2D5008BEFA1 /* ImageAttachment.swift in Sources */,
 				D73290BA2099F0AB0003F647 /* UndoData.swift in Sources */,
@@ -3589,6 +3590,7 @@
 				D7153DFD2285A93300A2C20F /* AboutWindowController.swift in Sources */,
 				D7CA7FC72326519600E9717A /* Git.swift in Sources */,
 				D77CC041216A608500582B97 /* EditorScrollView.swift in Sources */,
+				8F7136EE23490CBF004DFA6E /* Markdown.swift in Sources */,
 				D773DE801F36F45900A39C9F /* SandboxBookmark.swift in Sources */,
 				D7487F932173503C00D09383 /* AttributedBox.swift in Sources */,
 				D730BD3C222DB9FC00E69C93 /* NameHelper.swift in Sources */,

--- a/FSNotes.xcodeproj/project.pbxproj
+++ b/FSNotes.xcodeproj/project.pbxproj
@@ -3174,7 +3174,6 @@
 				"${BUILT_PRODUCTS_DIR}/DKPhotoGallery/DKPhotoGallery.framework",
 				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
-				"${BUILT_PRODUCTS_DIR}/SDWebImageFLPlugin/SDWebImageFLPlugin.framework",
 				"${BUILT_PRODUCTS_DIR}/Kanna/Kanna.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -3190,7 +3189,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKPhotoGallery.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageFLPlugin.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kanna.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FSNotes/Business/Markdown.swift
+++ b/FSNotes/Business/Markdown.swift
@@ -1,0 +1,40 @@
+//
+//  Markdown.swift
+//  FSNotes
+//
+//  Created by Wonsup Yoon on 05/10/2019.
+//  Copyright © 2019 Oleksandr Glushchenko. All rights reserved.
+//
+
+import libcmark_gfm
+
+
+func renderMarkdownHTML(markdown: String) -> String? {
+    
+    guard let parser = cmark_parser_new(CMARK_OPT_FOOTNOTES) else { return nil }
+    defer { cmark_parser_free(parser) }
+
+    if let ext = cmark_find_syntax_extension("table") {
+        cmark_parser_attach_syntax_extension(parser, ext)
+    }
+
+    if let ext = cmark_find_syntax_extension("autolink") {
+        cmark_parser_attach_syntax_extension(parser, ext)
+    }
+
+    if let ext = cmark_find_syntax_extension("strikethrough") {
+        cmark_parser_attach_syntax_extension(parser, ext)
+    }
+
+    if let ext = cmark_find_syntax_extension("mention") {
+        cmark_parser_attach_syntax_extension(parser, ext)
+    }
+
+    if let ext = cmark_find_syntax_extension("checkbox") {
+        cmark_parser_attach_syntax_extension(parser, ext)
+    }
+
+    cmark_parser_feed(parser, markdown, markdown.utf8.count)
+    guard let node = cmark_parser_finish(parser) else { return nil }
+    return String(cString: cmark_render_html(node, 0, nil))
+}

--- a/FSNotes/Business/Markdown.swift
+++ b/FSNotes/Business/Markdown.swift
@@ -27,12 +27,8 @@ func renderMarkdownHTML(markdown: String) -> String? {
     if let ext = cmark_find_syntax_extension("strikethrough") {
         cmark_parser_attach_syntax_extension(parser, ext)
     }
-
-    if let ext = cmark_find_syntax_extension("mention") {
-        cmark_parser_attach_syntax_extension(parser, ext)
-    }
-
-    if let ext = cmark_find_syntax_extension("checkbox") {
+    
+    if let ext = cmark_find_syntax_extension("tasklist") {
         cmark_parser_attach_syntax_extension(parser, ext)
     }
 

--- a/FSNotes/Business/Markdown.swift
+++ b/FSNotes/Business/Markdown.swift
@@ -11,6 +11,8 @@ import libcmark_gfm
 
 func renderMarkdownHTML(markdown: String) -> String? {
     
+    cmark_gfm_core_extensions_ensure_registered()
+    
     guard let parser = cmark_parser_new(CMARK_OPT_FOOTNOTES) else { return nil }
     defer { cmark_parser_free(parser) }
 

--- a/FSNotes/MPreviewView.swift
+++ b/FSNotes/MPreviewView.swift
@@ -7,7 +7,6 @@
 //
 
 import WebKit
-import cmark_gfm_swift
 import Carbon.HIToolbox
 
 #if os(iOS)
@@ -94,8 +93,7 @@ class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
     }
 
     func loadHTMLView(_ markdownString: String, css: String, imagesStorage: URL? = nil) throws {
-        let node = Node(markdown: markdownString)
-        var htmlString = node!.html
+        var htmlString = renderMarkdownHTML(markdown: markdownString)!
 
         if let imagesStorage = imagesStorage {
             htmlString = loadImages(imagesStorage: imagesStorage, html: htmlString)

--- a/FSNotes/View/EditTextView.swift
+++ b/FSNotes/View/EditTextView.swift
@@ -7,7 +7,6 @@
 //
 
 import Cocoa
-import Down
 import Highlightr
 import Carbon.HIToolbox
 import FSNotesCore_macOS

--- a/FSNotes/View/MarkdownView.swift
+++ b/FSNotes/View/MarkdownView.swift
@@ -8,7 +8,6 @@
 
 import WebKit
 import Highlightr
-import cmark_gfm_swift
 
 #if os(iOS)
 import NightNight
@@ -198,8 +197,7 @@ private extension MarkdownView {
     
     func loadHTMLView(_ markdownString: String, css: String, imagesStorage: URL? = nil) throws {
 
-        let node = Node(markdown: markdownString)
-        var htmlString = node!.html
+        var htmlString = renderMarkdownHTML(markdown: markdownString)!
 
         if let imagesStorage = imagesStorage {
             htmlString = loadImages(imagesStorage: imagesStorage, html: htmlString)

--- a/FSNotes/ViewController+Print.swift
+++ b/FSNotes/ViewController+Print.swift
@@ -7,7 +7,6 @@
 //
 
 import WebKit
-import cmark_gfm_swift
 
 extension ViewController {
 
@@ -41,7 +40,7 @@ extension ViewController {
         var template = try! NSString(contentsOf: baseURL, encoding: String.Encoding.utf8.rawValue)
         template = template.replacingOccurrences(of: "DOWN_CSS", with: css) as NSString
 
-        let html = Node(markdown: markdownString)!.html
+        let html = renderMarkdownHTML(markdown: markdownString)!
         var htmlString = template.replacingOccurrences(of: "DOWN_HTML", with: html)
         var imagesStorage = note.project.url
 

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -8,7 +8,6 @@
 
 import Cocoa
 import MASShortcut
-import cmark_gfm_swift
 import FSNotesCore_macOS
 import WebKit
 import LocalAuthentication
@@ -1978,8 +1977,7 @@ class ViewController: NSViewController,
     
     public func saveHtmlAtClipboard() {
         if let note = notesTableView.getSelectedNote() {
-            if let node = Node(markdown: note.content.string) {
-                let render = node.html
+            if let render = renderMarkdownHTML(markdown: note.content.string) {
                 let pasteboard = NSPasteboard.general
                 pasteboard.declareTypes([NSPasteboard.PasteboardType.string], owner: nil)
                 pasteboard.setString(render, forType: NSPasteboard.PasteboardType.string)

--- a/Podfile
+++ b/Podfile
@@ -15,9 +15,8 @@ end
 
 def common_pods
     pod 'Highlightr', :git => 'https://github.com/glushchenko/Highlightr.git', :branch => 'master'
-    pod 'Down', '~> 0.8.3'
-    pod 'cmark-gfm-swift', :git => 'https://github.com/glushchenko/cmark-gfm-swift.git', :branch => 'master'
-    pod 'RNCryptor', '~> 5.1.0'
+    pod 'libcmark_gfm', :git => 'https://github.com/KristopherGBaker/libcmark_gfm.git', :branch => 'master' 
+	pod 'RNCryptor', '~> 5.1.0'
     pod 'SSZipArchive', :git => 'https://github.com/glushchenko/ZipArchive.git', :branch => 'master'
 end
 


### PR DESCRIPTION
PR for #703

Module added:
- libcmark_gfm

Module removed:
- cmark-gfm-swift
- Down (conflict with libcmark_gfm, it seems not used)

New features:
- Footnotes (still need to fix, it opens external editor)
- Braket links with white spaces (ex. [Hello world](<Hello world.md>)

Note:
- Add additional file `FSNotes/Business/Markdown.swift`.
   It contains single function which renders markdown as HTML.
- Add an  option `CMARK_OPT_FOOTNOTES` to `cmark_parser_new`
   for footnotes.