### PR TITLE
Update intro files

### DIFF
--- a/Resources/Initial/FSNotes - Shortcuts.md
+++ b/Resources/Initial/FSNotes - Shortcuts.md
@@ -1,15 +1,15 @@
 ## Shortcuts
 
-This is **markdown** and **RTF** text manager. For view rendered markdown please use preview mode, shortcut – ```command + ~```, or click ```View -> Toggle preview```.
+This is **markdown** and **RTF** text manager. For view rendered markdown please use preview mode, shortcut – ``command + ` ``, or click `View -> Toggle preview`.
 
 ### Keyboard shortcuts
 
 #### Global
 
-- `command + option + shift + L` - open main window and focus search bar
-- `command + option + shift + n` - save clipboard
+- `cmd + option + shift + L` - open main window and focus search bar
+- `cmd + option + shift + n` - save clipboard
 - `enter` - move focus right (deeper); sidebar > note list > note
-- `command + enter` - move focus left (higher); note > note list > sidebar
+- `cmd + enter` - move focus left (higher); note > note list > sidebar
 
 #### Search and create field
 
@@ -21,24 +21,30 @@ This is **markdown** and **RTF** text manager. For view rendered markdown please
 - `esc` - move cursor into search bar and clear edit/search fields
 - `cmd + L` - move cursor into search bar
 - `tab` - go to next field
-- `cmd + ~` - preview mode (markdown only)
+- ``cmd + ` `` - preview mode (markdown only)
 - `up, down arrows` - select note
-- `command + j` - next note
-- `command + k` - previous note
+- `cmd + j` - next note
+- `cmd + k` - previous note
 
 #### Notes list
 
 - `cmd + delete` - remove note
 - `cmd + r` - rename note
 - `cmd + 8` - pin note
+- `cmd + 7` - remove encryption (un encrypt previously encrypted note)
 - `cmd + n` - make note
 - `cmd + shift + n` - make RTF
-- `control + cmd + e` – open selected in external editor
-- `control + cmd + o` – show selected in finder
+- `ctrl + cmd + e` – open selected in external editor
+- `ctrl + cmd + o` – show selected in finder
 - `shift + cmd + m` – move selected note in storage
 - `shift + cmd + b` – hide sidebar
+- `cmd + s` – save revision in git
+- `cmd + d` – duplicate note
+- `cmd + alt + l` - encrypt/decrypt note (AES 256)
 
 #### Editor
 
 - `fn + f5` - autocomplete note name
+- ``cmd + ` ``, or click `View -> Toggle preview` - for preview rendered markdown
+
 

--- a/Resources/Welcome.bundle/1.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/1.textbundle/text.markdown
@@ -1,10 +1,13 @@
 ## 1. Introduction
 
-Hi, my name is Alex and I am the author of this program. A few years ago, I discovered that my favorite note-taking application, nvALT, no longer starts. None of the existing alternatives for macOS and iOS suited me, and since I have been developing for many years, I tried to write my own solution. In the summer of 2017, I published the source code of FSNotes on GitHub, it was a terrible application 🤬. Terrible and with poor functionality. But I did not give up, contributors did not either. 
-At this moment, FSNotes is translated into 8 languages and used across the globe. The number of features has exceeded one hundred, of which dozens are unique.
+Hi, my name is Alex and I am the author of this program. A few years ago, I discovered that my favorite note-taking application, nvALT, no longer starts.
+
+None of the existing alternatives for macOS and iOS suited me, and since I have been developing for many years, I tried to write my own solution. In the summer of 2017, I published the source code of FSNotes on GitHub. It was a terrible application 🤬. Terrible and with poor functionality. But I did not give up and contributors did not either.
+
+At this time, FSNotes is translated into 8 languages and used across the globe. The number of features has exceeded one hundred, of which dozens are unique.
 
 If you like this app - please support development, buy the application in [Mac App Store](https://apps.apple.com/app/fsnotes/id1277179284) and [AppStore](https://apps.apple.com/app/fsnotes-manager/id1346501102) for mobile FSNotes experience.
 
--- 
+--
 Kind Regards,
 FSNotes author, Alex

--- a/Resources/Welcome.bundle/2.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/2.textbundle/text.markdown
@@ -4,15 +4,15 @@
 
 FSNotes respects open formats: **plain/text, markdown, rtf**, and stores data in the file system. You can view, edit, and copy data in your favourite external editor and see live results in FSNotes.
 
-### Table of content 
+### Table of content
 
 - [[Shortcuts]]
-- [[Code highlighting]] 
+- [[Code highlighting]]
 - [[Tags and subtags]]
 - [[Git powered history]]
-- [[Mermaid nad MathJax]]
+- [[Mermaid and MathJax]]
 - [[Sidebar]]
-- [[Containers]]  
+- [[Containers]]
 
 #### Key features
 
@@ -35,10 +35,10 @@ FSNotes respects open formats: **plain/text, markdown, rtf**, and stores data in
 - Encryption AES-256.
 - Mermaid and MathJax support.
 - Git versioning and scheduled backups.
-  
+
 #### Links
 
-Official site: https://fsnot.es  
-Issues: https://github.com/glushchenko/fsnotes/issues  
-Wiki: https://github.com/glushchenko/fsnotes/wiki  
+Official site: https://fsnot.es
+Issues: https://github.com/glushchenko/fsnotes/issues
+Wiki: https://github.com/glushchenko/fsnotes/wiki
 Announces: https://twitter.com/fsnotesapp

--- a/Resources/Welcome.bundle/4.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/4.textbundle/text.markdown
@@ -6,10 +6,10 @@ FSNotes respects mouseless usage, it is shortcuts friendly app.
 
 #### Global
 
-- `command + option + shift + L` - open main window and focus search bar
-- `command + option + shift + n` - save clipboard
+- `cmd + option + shift + L` - open main window and focus search bar
+- `cmd + option + shift + n` - save clipboard
 - `enter` - move focus right (deeper); sidebar > note list > note
-- `command + enter` - move focus left (higher); note > note list > sidebar
+- `cmd + enter` - move focus left (higher); note > note list > sidebar
 
 #### Search and create field
 
@@ -21,10 +21,10 @@ FSNotes respects mouseless usage, it is shortcuts friendly app.
 - `esc` - move cursor into search bar and clear edit/search fields
 - `cmd + L` - move cursor into search bar
 - `tab` - go to next field
-- `cmd + ~` - preview mode (markdown only)
+- ``cmd + ` `` - preview mode (markdown only)
 - `up, down arrows` - select note
-- `command + j` - next note
-- `command + k` - previous note
+- `cmd + j` - next note
+- `cmd + k` - previous note
 
 #### Notes list
 
@@ -34,8 +34,8 @@ FSNotes respects mouseless usage, it is shortcuts friendly app.
 - `cmd + 7` - remove encryption (un encrypt previously encrypted note)
 - `cmd + n` - make note
 - `cmd + shift + n` - make RTF
-- `control + cmd + e` – open selected in external editor
-- `control + cmd + o` – show selected in finder
+- `ctrl + cmd + e` – open selected in external editor
+- `ctrl + cmd + o` – show selected in finder
 - `shift + cmd + m` – move selected note in storage
 - `shift + cmd + b` – hide sidebar
 - `cmd + s` – save revision in git
@@ -45,6 +45,6 @@ FSNotes respects mouseless usage, it is shortcuts friendly app.
 #### Editor
 
 - `fn + f5` - autocomplete note name
-- `command + ~`, or click `View -> Toggle preview` - for preview rendered markdown
+- ``cmd + ` ``, or click `View -> Toggle preview` - for preview rendered markdown
 
 

--- a/Resources/Welcome.bundle/5.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/5.textbundle/text.markdown
@@ -6,7 +6,7 @@ You can select and filter unlimited projects and tags.
 
 ### Each subfolder is a project
 
-Make unlimited folders inside your storage. Right click on root folder and click "New folder" `cmd + shift + n`.
+Make unlimited folders inside your storage. Right click on root folder (`Documents`) and click "New folder" `⌥ option + ⇧ shift + n`.
 
 Each project has its own settings, right click on the project - "Show view options" `cmd + shift + ,`.
 

--- a/Resources/Welcome.bundle/6.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/6.textbundle/text.markdown
@@ -1,6 +1,6 @@
 ## 6. Tags and subtags
 
-FSNotes version 4 brings an amazing inline tags system. Tag notes simply by prepending a word ith hash (#). Like this: #hello. Or, subtag them like this: #hello/world. How deep can you sub-tag your notes? Well, #unlimited/sub/tags. Tags auto-complete, too. Type a hash and the first character for your tag and:
+FSNotes version 4 brings an amazing inline tags system. Tag notes simply by prepending a word with a hash (#). Like this: #hello. Or, subtag them like this: #hello/world. How deep can you sub-tag your notes? Well, #unlimited/sub/tags. Tags auto-complete, too. Type a hash and the first character for your tag and:
 
 ![](assets/520e395f-7924-4499-9587-6006a182c685.jpg)
 

--- a/Resources/Welcome.bundle/7.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/7.textbundle/text.markdown
@@ -1,6 +1,6 @@
-## 7. Mermaid nad MathJax
+## 7. Mermaid and MathJax
 
-### Mermaid  example
+### Mermaid example
 
 Documentation: https://mermaidjs.github.io
 


### PR DESCRIPTION
Hi!

I just found FSNotes and love it so far. As I was going through the welcoming flow (which is fantastic by the way), I found a few things that might be tweaked.

Many of these are small grammar and typographic changes.

One keyboard shortcut I found difficult was the Preview Mode. Technically it's command + ` since the ~ is achieved by shift + `. 

Trying to add clarity, I escaped the tick (`) character using this trick: https://meta.stackexchange.com/questions/82718/how-do-i-escape-a-backtick-within-in-line-code-in-markdown.

P.s. The `FSNotes - README.md` file includes a link to `[[Shortcuts]]` but this is not included in the bundle for iOS. 
