### PR TITLE
Fixed resizing master view issue in Preview mode

### DIFF
--- a/FSNotes/MPreviewView.swift
+++ b/FSNotes/MPreviewView.swift
@@ -17,12 +17,12 @@ public typealias MPreviewViewClosure = () -> ()
 
 class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
 
+    private weak var note: Note?
     private var closure: MPreviewViewClosure?
     public static var template: String?
-
+    
     init(frame: CGRect, note: Note, closure: MPreviewViewClosure?) {
         self.closure = closure
-        
         let userContentController = WKUserContentController()
         userContentController.add(HandlerSelection(), name: "newSelectionDetected")
 
@@ -91,6 +91,8 @@ class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
     }
 
     public func load(note: Note) {
+        guard self.note != note else { return }
+        
         let markdownString = note.getPrettifiedContent()
         let css = MarkdownView.getPreviewStyle()
 
@@ -105,6 +107,8 @@ class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
         } else {
             fastLoading(note: note, markdown: markdownString, css: css)
         }
+        
+        self.note = note
     }
 
     public func cleanCache() {

--- a/FSNotes/MPreviewView.swift
+++ b/FSNotes/MPreviewView.swift
@@ -91,6 +91,7 @@ class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
     }
 
     public func load(note: Note) {
+        /// Do not re-load already loaded view
         guard self.note != note else { return }
         
         let markdownString = note.getPrettifiedContent()

--- a/FSNotes/View/EditTextView.swift
+++ b/FSNotes/View/EditTextView.swift
@@ -502,7 +502,12 @@ class EditTextView: NSTextView, NSTextFinderClient {
                     viewController.editAreaScroll.addSubview(view)
                 }
             } else {
-                markdownView!.load(note: note)
+                /// Resize markdownView
+                let frame = viewController.editAreaScroll.bounds
+                markdownView?.frame = frame
+                
+                /// Load note if needed
+                markdownView?.load(note: note)
             }
             return
         }

--- a/FSNotes/View/EditorSplitView.swift
+++ b/FSNotes/View/EditorSplitView.swift
@@ -45,6 +45,10 @@ class EditorSplitView: NSSplitView, NSSplitViewDelegate {
         }
     }
 
+    func splitViewDidResizeSubviews(_ notification: Notification) {
+        ViewController.shared()?.resizeView()
+    }
+    
     func splitViewWillResizeSubviews(_ notification: Notification) {
         if let vc = ViewController.shared() {
             vc.editArea.updateTextContainerInset()

--- a/FSNotes/View/EditorSplitView.swift
+++ b/FSNotes/View/EditorSplitView.swift
@@ -46,7 +46,7 @@ class EditorSplitView: NSSplitView, NSSplitViewDelegate {
     }
 
     func splitViewDidResizeSubviews(_ notification: Notification) {
-        ViewController.shared()?.resizeView()
+        ViewController.shared()?.viewDidResize()
     }
     
     func splitViewWillResizeSubviews(_ notification: Notification) {

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -494,7 +494,7 @@ class ViewController: NSViewController,
         }
     }
 
-    func resizeView() {
+    func viewDidResize() {
         guard let vc = ViewController.shared() else { return }
         vc.checkSidebarConstraint()
                 

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -494,7 +494,7 @@ class ViewController: NSViewController,
         }
     }
 
-    func splitViewDidResizeSubviews(_ notification: Notification) {
+    func resizeView() {
         guard let vc = ViewController.shared() else { return }
         vc.checkSidebarConstraint()
                 


### PR DESCRIPTION
There were a few issues while resizing the master view in preview mode.
Before:
![before3](https://user-images.githubusercontent.com/78059/72690537-fea0c800-3b25-11ea-9e41-5d6d283f9f79.gif)

After:
![after3](https://user-images.githubusercontent.com/78059/72690546-09f3f380-3b26-11ea-931a-9b9d1d8586eb.gif)

I removed `splitViewDidResizeSubviews` from ViewController as it did not detect resizing by dragging splitView divider but only resizing the whole window size. But I added `splitViewDidResizeSubviews` to `EditorSplitView.swift` so now it handles resizing no matter how you resize the views. This also fixes the resizing issue while switching to fullscreen in preview mode.

Added check to stop loading note if it is the same as the current note. It was made to optimize performance.