### PR TITLE
Fix for #765: Change default value for Text Replacement from False to True

### DIFF
--- a/FSNotes/Helpers/UserDefaultsManagement.swift
+++ b/FSNotes/Helpers/UserDefaultsManagement.swift
@@ -806,7 +806,7 @@ public class UserDefaultsManagement {
             if let result = UserDefaults.standard.object(forKey: Constants.AutomaticTextReplacement) {
                 return result as! Bool
             }
-            return false
+            return true
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Constants.AutomaticTextReplacement)


### PR DESCRIPTION
I'm not sure about default values for other substitutions (smart links, smart quotes, smart dashes, etc. I would turn them on as well) but Text Replacement should be true by default.