### PR TITLE
Fix an issue when title covers lock and preview buttons after being edited

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1581,17 +1581,22 @@ CA
                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="xSU-Mk-2F1" customClass="TitleBarView" customModule="FSNotes" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="562" width="462" height="38"/>
                                                         <subviews>
-                                                            <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ua8-RE-q01">
-                                                                <rect key="frame" x="0.0" y="0.0" width="462" height="38"/>
+                                                            <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ" customClass="TitleTextField" customModule="FSNotes" customModuleProvider="target">
+                                                                <rect key="frame" x="85" y="11" width="292" height="16"/>
+                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" enabled="NO" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="mainBackground"/>
+                                                                </textFieldCell>
+                                                                <connections>
+                                                                    <outlet property="delegate" destination="XfG-lQ-9wD" id="ikK-Ty-iHC"/>
+                                                                </connections>
+                                                            </textField>
+                                                            <customView horizontalHuggingPriority="249" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="Ua8-RE-q01">
+                                                                <rect key="frame" x="377" y="0.0" width="85" height="38"/>
                                                                 <subviews>
-                                                                    <box hidden="YES" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sIv-nk-gch">
-                                                                        <rect key="frame" x="0.0" y="-2" width="462" height="5"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="0.5" id="Cgx-T0-tZD"/>
-                                                                        </constraints>
-                                                                    </box>
-                                                                    <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="9" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="shI-kr-3o8">
-                                                                        <rect key="frame" x="400" y="11" width="50" height="16"/>
+                                                                    <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="9" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="shI-kr-3o8">
+                                                                        <rect key="frame" x="12" y="11" width="61" height="16"/>
                                                                         <subviews>
                                                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Ote-7U-BZm">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="10" height="16"/>
@@ -1622,7 +1627,7 @@ CA
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDB-Y6-20P">
-                                                                                <rect key="frame" x="50" y="0.0" width="0.0" height="16"/>
+                                                                                <rect key="frame" x="50" y="0.0" width="11" height="16"/>
                                                                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSShareTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="vLT-o6-WGO">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                                     <font key="font" metaFont="system"/>
@@ -1645,33 +1650,22 @@ CA
                                                                     </stackView>
                                                                 </subviews>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="bottom" secondItem="sIv-nk-gch" secondAttribute="bottom" id="8zI-PO-LGd"/>
                                                                     <constraint firstItem="shI-kr-3o8" firstAttribute="centerY" secondItem="Ua8-RE-q01" secondAttribute="centerY" id="AVX-pD-7Dr"/>
-                                                                    <constraint firstItem="sIv-nk-gch" firstAttribute="leading" secondItem="Ua8-RE-q01" secondAttribute="leading" id="FzU-YG-fYc"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="sIv-nk-gch" secondAttribute="trailing" id="LlO-H5-hxQ"/>
                                                                     <constraint firstAttribute="trailing" secondItem="shI-kr-3o8" secondAttribute="trailing" constant="12" id="PPb-lX-xlt"/>
+                                                                    <constraint firstItem="shI-kr-3o8" firstAttribute="leading" secondItem="Ua8-RE-q01" secondAttribute="leading" constant="12" id="pyO-IT-LKf"/>
                                                                 </constraints>
                                                             </customView>
                                                         </subviews>
                                                         <constraints>
+                                                            <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" secondItem="xSU-Mk-2F1" secondAttribute="leading" constant="85" id="1I0-Qm-T21"/>
+                                                            <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerY" secondItem="xSU-Mk-2F1" secondAttribute="centerY" id="3lf-bf-dJA"/>
                                                             <constraint firstAttribute="trailing" secondItem="Ua8-RE-q01" secondAttribute="trailing" id="Uos-hm-kn6"/>
-                                                            <constraint firstItem="Ua8-RE-q01" firstAttribute="leading" secondItem="xSU-Mk-2F1" secondAttribute="leading" id="duB-fQ-EQf"/>
+                                                            <constraint firstAttribute="trailing" secondItem="rZx-hk-GcJ" secondAttribute="trailing" constant="85" id="ZjM-uT-4wC"/>
                                                             <constraint firstItem="Ua8-RE-q01" firstAttribute="top" secondItem="xSU-Mk-2F1" secondAttribute="top" id="esv-qQ-apf"/>
                                                             <constraint firstAttribute="bottom" secondItem="Ua8-RE-q01" secondAttribute="bottom" id="nac-xp-D3Y"/>
                                                             <constraint firstAttribute="height" constant="38" id="uht-o4-cfz"/>
                                                         </constraints>
                                                     </customView>
-                                                    <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ" customClass="TitleTextField" customModule="FSNotes" customModuleProvider="target">
-                                                        <rect key="frame" x="20" y="573" width="360" height="16"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
-                                                            <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="mainBackground"/>
-                                                        </textFieldCell>
-                                                        <connections>
-                                                            <outlet property="delegate" destination="XfG-lQ-9wD" id="ikK-Ty-iHC"/>
-                                                        </connections>
-                                                    </textField>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" alphaValue="0.29999999999999999" translatesAutoresizingMaskIntoConstraints="NO" id="Gz4-4G-Fts">
                                                         <rect key="frame" x="249" y="250" width="70" height="99"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
@@ -1681,15 +1675,11 @@ CA
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="8Ne-do-Q9o"/>
-                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" constant="20" id="9Sl-l7-wNT"/>
-                                                    <constraint firstItem="shI-kr-3o8" firstAttribute="leading" secondItem="rZx-hk-GcJ" secondAttribute="trailing" priority="999" constant="20" id="AGn-iT-pzF"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="CQ0-DY-aM0"/>
-                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerY" secondItem="xSU-Mk-2F1" secondAttribute="centerY" id="Ett-1f-HTb"/>
                                                     <constraint firstAttribute="trailing" secondItem="qJO-7f-vkL" secondAttribute="trailing" id="GZ2-jz-8Ue"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="top" secondItem="xSU-Mk-2F1" secondAttribute="bottom" id="NMQ-Tc-leL"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="top" secondItem="at7-wA-VAS" secondAttribute="top" id="Nm9-X5-Q67"/>
                                                     <constraint firstAttribute="trailing" secondItem="xSU-Mk-2F1" secondAttribute="trailing" id="Te8-se-icR"/>
-                                                    <constraint firstAttribute="trailing" secondItem="rZx-hk-GcJ" secondAttribute="trailing" priority="995" constant="20" id="UCd-6M-rsb"/>
                                                     <constraint firstAttribute="bottom" secondItem="qJO-7f-vkL" secondAttribute="bottom" id="hij-XA-hAd"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="inr-29-Y1D"/>
                                                 </constraints>
@@ -1737,9 +1727,7 @@ CA
                         <outlet property="storageOutlineView" destination="urA-eK-bWB" id="ytX-z3-4Mi"/>
                         <outlet property="titleBarAdditionalView" destination="Ua8-RE-q01" id="CfN-3p-UH3"/>
                         <outlet property="titleBarView" destination="xSU-Mk-2F1" id="lbu-pA-1Hs"/>
-                        <outlet property="titleFullTrailingConstraint" destination="UCd-6M-rsb" id="6eB-l3-bUm"/>
                         <outlet property="titleLabel" destination="rZx-hk-GcJ" id="wKj-zD-Ovz"/>
-                        <outlet property="titleShortTrailingConstraint" destination="AGn-iT-pzF" id="vkn-qK-B7k"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1257,7 +1257,7 @@ CA
                                                             <tableColumns>
                                                                 <tableColumn width="141" minWidth="16" maxWidth="1000" id="Gwp-vX-YaR">
                                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Library">
-                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <font key="font" metaFont="label" size="11"/>
                                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                     </tableHeaderCell>
@@ -1406,7 +1406,7 @@ CA
                                                                     <tableColumns>
                                                                         <tableColumn editable="NO" width="236" maxWidth="2000" id="aKf-mj-22P">
                                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                                                <font key="font" metaFont="message" size="11"/>
+                                                                                <font key="font" metaFont="label" size="11"/>
                                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                             </tableHeaderCell>
@@ -1578,11 +1578,11 @@ CA
                                                             <autoresizingMask key="autoresizingMask"/>
                                                         </scroller>
                                                     </scrollView>
-                                                    <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xSU-Mk-2F1" customClass="TitleBarView" customModule="FSNotes" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="562" width="568" height="38"/>
+                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="xSU-Mk-2F1" customClass="TitleBarView" customModule="FSNotes" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="562" width="462" height="38"/>
                                                         <subviews>
-                                                            <customView hidden="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ua8-RE-q01">
-                                                                <rect key="frame" x="0.0" y="0.0" width="568" height="38"/>
+                                                            <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ua8-RE-q01">
+                                                                <rect key="frame" x="0.0" y="0.0" width="462" height="38"/>
                                                                 <subviews>
                                                                     <box hidden="YES" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sIv-nk-gch">
                                                                         <rect key="frame" x="0.0" y="-2" width="462" height="5"/>
@@ -1590,55 +1590,66 @@ CA
                                                                             <constraint firstAttribute="height" constant="0.5" id="Cgx-T0-tZD"/>
                                                                         </constraints>
                                                                     </box>
-                                                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oDB-Y6-20P">
-                                                                        <rect key="frame" x="545" y="11" width="11" height="16"/>
-                                                                        <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSShareTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="vLT-o6-WGO">
-                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                            <font key="font" metaFont="system"/>
-                                                                        </buttonCell>
-                                                                        <connections>
-                                                                            <action selector="shareSheet:" target="rPt-NT-nkU" id="Kfd-pJ-Bqc"/>
-                                                                        </connections>
-                                                                    </button>
-                                                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bn7-FD-jzc">
-                                                                        <rect key="frame" x="513" y="11" width="22" height="16"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="width" constant="22" id="cL1-PF-gSQ"/>
-                                                                            <constraint firstAttribute="height" constant="16" id="mhf-Ok-C0D"/>
-                                                                        </constraints>
-                                                                        <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="NSQuickLookTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Yk7-v6-QmI">
-                                                                            <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                                                                            <font key="font" metaFont="system"/>
-                                                                        </buttonCell>
-                                                                        <connections>
-                                                                            <action selector="togglePreview:" target="XfG-lQ-9wD" id="Mf0-5U-8VP"/>
-                                                                        </connections>
-                                                                    </button>
-                                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ote-7U-BZm">
-                                                                        <rect key="frame" x="495" y="11" width="10" height="16"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="16" id="KX9-jI-cyF"/>
-                                                                            <constraint firstAttribute="width" constant="10" id="fyl-XF-faY"/>
-                                                                        </constraints>
-                                                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSLockLockedTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="aHW-dK-rqB">
-                                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                            <font key="font" metaFont="system"/>
-                                                                        </buttonCell>
-                                                                        <connections>
-                                                                            <action selector="toggleNotesLock:" target="XfG-lQ-9wD" id="wku-AS-7EO"/>
-                                                                        </connections>
-                                                                    </button>
+                                                                    <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="9" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="shI-kr-3o8">
+                                                                        <rect key="frame" x="400" y="11" width="50" height="16"/>
+                                                                        <subviews>
+                                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Ote-7U-BZm">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="10" height="16"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="height" constant="16" id="KX9-jI-cyF"/>
+                                                                                    <constraint firstAttribute="width" constant="10" id="fyl-XF-faY"/>
+                                                                                </constraints>
+                                                                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSLockLockedTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="aHW-dK-rqB">
+                                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                </buttonCell>
+                                                                                <connections>
+                                                                                    <action selector="toggleNotesLock:" target="XfG-lQ-9wD" id="wku-AS-7EO"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Bn7-FD-jzc">
+                                                                                <rect key="frame" x="19" y="0.0" width="22" height="16"/>
+                                                                                <constraints>
+                                                                                    <constraint firstAttribute="width" constant="22" id="cL1-PF-gSQ"/>
+                                                                                    <constraint firstAttribute="height" constant="16" id="mhf-Ok-C0D"/>
+                                                                                </constraints>
+                                                                                <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="NSQuickLookTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Yk7-v6-QmI">
+                                                                                    <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                </buttonCell>
+                                                                                <connections>
+                                                                                    <action selector="togglePreview:" target="XfG-lQ-9wD" id="Mf0-5U-8VP"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDB-Y6-20P">
+                                                                                <rect key="frame" x="50" y="0.0" width="0.0" height="16"/>
+                                                                                <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSShareTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="vLT-o6-WGO">
+                                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                </buttonCell>
+                                                                                <connections>
+                                                                                    <action selector="shareSheet:" target="rPt-NT-nkU" id="Kfd-pJ-Bqc"/>
+                                                                                </connections>
+                                                                            </button>
+                                                                        </subviews>
+                                                                        <visibilityPriorities>
+                                                                            <integer value="1000"/>
+                                                                            <integer value="1000"/>
+                                                                            <integer value="1000"/>
+                                                                        </visibilityPriorities>
+                                                                        <customSpacing>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                            <real value="3.4028234663852886e+38"/>
+                                                                        </customSpacing>
+                                                                    </stackView>
                                                                 </subviews>
                                                                 <constraints>
-                                                                    <constraint firstItem="Bn7-FD-jzc" firstAttribute="centerY" secondItem="oDB-Y6-20P" secondAttribute="centerY" id="5ca-la-z4K"/>
                                                                     <constraint firstAttribute="bottom" secondItem="sIv-nk-gch" secondAttribute="bottom" id="8zI-PO-LGd"/>
-                                                                    <constraint firstItem="oDB-Y6-20P" firstAttribute="centerY" secondItem="Ua8-RE-q01" secondAttribute="centerY" id="CqL-TZ-knJ"/>
+                                                                    <constraint firstItem="shI-kr-3o8" firstAttribute="centerY" secondItem="Ua8-RE-q01" secondAttribute="centerY" id="AVX-pD-7Dr"/>
                                                                     <constraint firstItem="sIv-nk-gch" firstAttribute="leading" secondItem="Ua8-RE-q01" secondAttribute="leading" id="FzU-YG-fYc"/>
-                                                                    <constraint firstItem="Ote-7U-BZm" firstAttribute="centerY" secondItem="Ua8-RE-q01" secondAttribute="centerY" id="GEa-vV-SOX"/>
-                                                                    <constraint firstItem="oDB-Y6-20P" firstAttribute="leading" secondItem="Bn7-FD-jzc" secondAttribute="trailing" constant="10" id="Gen-sI-BLY"/>
                                                                     <constraint firstAttribute="trailing" secondItem="sIv-nk-gch" secondAttribute="trailing" id="LlO-H5-hxQ"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="oDB-Y6-20P" secondAttribute="trailing" constant="8" id="Vjg-yM-FoF"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="Ote-7U-BZm" secondAttribute="trailing" constant="63" id="vJ1-vr-2an"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="shI-kr-3o8" secondAttribute="trailing" constant="12" id="PPb-lX-xlt"/>
                                                                 </constraints>
                                                             </customView>
                                                         </subviews>
@@ -1651,7 +1662,7 @@ CA
                                                         </constraints>
                                                     </customView>
                                                     <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="rZx-hk-GcJ" customClass="TitleTextField" customModule="FSNotes" customModuleProvider="target">
-                                                        <rect key="frame" x="214" y="573" width="35" height="16"/>
+                                                        <rect key="frame" x="20" y="573" width="360" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Title" drawsBackground="YES" id="O9K-a1-3eu">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1669,16 +1680,16 @@ CA
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerX" secondItem="at7-wA-VAS" secondAttribute="centerX" id="1uj-pH-by2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="8Ne-do-Q9o"/>
-                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="at7-wA-VAS" secondAttribute="leading" constant="20" id="9Sl-l7-wNT"/>
-                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rZx-hk-GcJ" secondAttribute="trailing" constant="20" id="Ai3-Ih-AZU"/>
+                                                    <constraint firstItem="rZx-hk-GcJ" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" constant="20" id="9Sl-l7-wNT"/>
+                                                    <constraint firstItem="shI-kr-3o8" firstAttribute="leading" secondItem="rZx-hk-GcJ" secondAttribute="trailing" priority="999" constant="20" id="AGn-iT-pzF"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="CQ0-DY-aM0"/>
                                                     <constraint firstItem="rZx-hk-GcJ" firstAttribute="centerY" secondItem="xSU-Mk-2F1" secondAttribute="centerY" id="Ett-1f-HTb"/>
                                                     <constraint firstAttribute="trailing" secondItem="qJO-7f-vkL" secondAttribute="trailing" id="GZ2-jz-8Ue"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="top" secondItem="xSU-Mk-2F1" secondAttribute="bottom" id="NMQ-Tc-leL"/>
                                                     <constraint firstItem="xSU-Mk-2F1" firstAttribute="top" secondItem="at7-wA-VAS" secondAttribute="top" id="Nm9-X5-Q67"/>
                                                     <constraint firstAttribute="trailing" secondItem="xSU-Mk-2F1" secondAttribute="trailing" id="Te8-se-icR"/>
+                                                    <constraint firstAttribute="trailing" secondItem="rZx-hk-GcJ" secondAttribute="trailing" priority="995" constant="20" id="UCd-6M-rsb"/>
                                                     <constraint firstAttribute="bottom" secondItem="qJO-7f-vkL" secondAttribute="bottom" id="hij-XA-hAd"/>
                                                     <constraint firstItem="qJO-7f-vkL" firstAttribute="leading" secondItem="at7-wA-VAS" secondAttribute="leading" id="inr-29-Y1D"/>
                                                 </constraints>
@@ -1726,7 +1737,9 @@ CA
                         <outlet property="storageOutlineView" destination="urA-eK-bWB" id="ytX-z3-4Mi"/>
                         <outlet property="titleBarAdditionalView" destination="Ua8-RE-q01" id="CfN-3p-UH3"/>
                         <outlet property="titleBarView" destination="xSU-Mk-2F1" id="lbu-pA-1Hs"/>
+                        <outlet property="titleFullTrailingConstraint" destination="UCd-6M-rsb" id="6eB-l3-bUm"/>
                         <outlet property="titleLabel" destination="rZx-hk-GcJ" id="wKj-zD-Ovz"/>
+                        <outlet property="titleShortTrailingConstraint" destination="AGn-iT-pzF" id="vkn-qK-B7k"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -2906,7 +2919,7 @@ Korean 🇰🇷</string>
                                 <rect key="frame" x="52" y="285" width="265" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <pathCell key="cell" controlSize="small" selectable="YES" editable="YES" alignment="left" id="lBe-Pa-whI">
-                                    <font key="font" metaFont="message" size="11"/>
+                                    <font key="font" metaFont="label" size="11"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </pathCell>
                             </pathControl>

--- a/FSNotes/View/TitleTextField.swift
+++ b/FSNotes/View/TitleTextField.swift
@@ -59,8 +59,10 @@ class TitleTextField: NSTextField {
         }
 
         vc.updateTitle(newTitle: currentName)
-
+        self.resignFirstResponder()
         updateNotesTableView()
+        vc.titleLabel.isEditable = false
+        vc.titleLabel.isEnabled = false
     }
 
     public func updateNotesTableView() {

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -940,8 +940,8 @@ class ViewController: NSViewController,
         if vc.notesTableView.selectedRow > -1 {
             vc.titleLabel.isEditable = true
             vc.titleLabel.isEnabled = true
-            MainWindowController.shared()?.makeFirstResponder(titleLabel)
-            titleBarAdditionalView.alphaValue = 0
+            MainWindowController.shared()?.makeFirstResponder(vc.titleLabel)
+            vc.titleBarAdditionalView.alphaValue = 0
             
             if let note = EditTextView.note, note.getFileName().isValidUUID {
                 vc.titleLabel.stringValue = note.getFileName()

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -56,6 +56,9 @@ class ViewController: NSViewController,
     @IBOutlet weak var sidebarSplitView: NSSplitView!
     @IBOutlet weak var notesListCustomView: NSView!
     @IBOutlet weak var outlineHeader: OutlineHeaderView!
+    @IBOutlet weak var titleFullTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var titleShortTrailingConstraint: NSLayoutConstraint!
+    
     @IBOutlet weak var searchTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var titleLabel: TitleTextField! {
         didSet {
@@ -79,6 +82,8 @@ class ViewController: NSViewController,
                     NSAnimationContext.runAnimationGroup({ context in
                         context.duration = 0.25
                         self?.titleBarAdditionalView.isHidden = true
+                        self?.titleShortTrailingConstraint.priority = .defaultLow
+                        self?.titleFullTrailingConstraint.priority = .defaultHigh
                     }, completionHandler: nil)
                 }
             }
@@ -97,6 +102,8 @@ class ViewController: NSViewController,
                     NSAnimationContext.runAnimationGroup({ context in
                         context.duration = 0.25
                         self?.titleBarAdditionalView.isHidden = false
+                        self?.titleShortTrailingConstraint.priority = .defaultHigh
+                        self?.titleFullTrailingConstraint.priority = .defaultLow
                     }, completionHandler: nil)
                 }
             }


### PR DESCRIPTION
<img width="598" alt="Screenshot 2020-01-22 at 23 59 36" src="https://user-images.githubusercontent.com/78059/72938778-356c1d80-3d74-11ea-8323-cd0c8df50056.png">

• I made title look less distractive.
• The buttons view (action view?) now appears/disappears with animation by changing its alpha but not hiding the view.
• The action view now won't appear while title is being editing.
• Changed title editing behaviour: it was needed to click twice on it for the first time but then it was switching to edit mode by just one click. Now it always two clicks.