### PR TITLE
Set proper preview button state after app launch

### DIFF
--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -71,7 +71,11 @@ class ViewController: NSViewController,
     @IBOutlet weak var shareButton: NSButton!
     @IBOutlet weak var sortByOutlet: NSMenuItem!
     @IBOutlet weak var titleBarAdditionalView: NSView!
-    @IBOutlet weak var previewButton: NSButton!
+    @IBOutlet weak var previewButton: NSButton! {
+        didSet {
+            previewButton.state = UserDefaultsManagement.preview ? .on : .off
+        }
+    }
     @IBOutlet weak var titleBarView: TitleBarView! {
         didSet {
             titleBarView.onMouseExitedClosure = { [weak self] in


### PR DESCRIPTION
The preview button has wrong state after app launch.

Steps to reproduce:
1. Open the app and turn preview mode on. At this moment the preview button is turned on.
2. Relaunch the app
3. Verify the preview button

Actual result:
Notes are in preview mode but the button is turned **off**

Expected result:
Notes are in preview mode but the button is turned **on**