### PR TITLE
Fixed an issue when action buttons stop appearing after changing document's title

### DIFF
--- a/FSNotes/View/TitleTextField.swift
+++ b/FSNotes/View/TitleTextField.swift
@@ -40,6 +40,11 @@ class TitleTextField: NSTextField {
         let currentTitle = stringValue
         let currentName = note.getFileName()
 
+        defer {
+            updateNotesTableView()
+            editModeOff()
+        }
+        
         if currentName != currentTitle {
             let ext = note.url.pathExtension
             let dst = note.project.url.appendingPathComponent(currentTitle).appendingPathExtension(ext)
@@ -65,6 +70,18 @@ class TitleTextField: NSTextField {
         vc.titleLabel.isEnabled = false
     }
 
+    public func editModeOn() {
+        self.isEnabled = true
+        self.isEditable = true
+        
+        MainWindowController.shared()?.makeFirstResponder(self)
+    }
+    
+    public func editModeOff() {
+        self.isEnabled = false
+        self.isEditable = false
+    }
+    
     public func updateNotesTableView() {
         guard let vc = ViewController.shared(), let note = EditTextView.note else { return }
 

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -662,7 +662,7 @@ class ViewController: NSViewController,
 
             // Renaming is in progress
             if titleLabel.isEditable {
-                titleLabel.isEditable = false
+                titleLabel.editModeOff()
                 titleLabel.window?.makeFirstResponder(notesTableView)
                 return false
             }
@@ -712,7 +712,7 @@ class ViewController: NSViewController,
             && !event.modifierFlags.contains(.option)
         ) {
             if titleLabel.isEditable {
-                titleLabel.isEditable = false
+                titleLabel.editModeOff()
                 titleLabel.window?.makeFirstResponder(nil)
             }
 
@@ -723,7 +723,7 @@ class ViewController: NSViewController,
         // Prev note (cmd-k)
         if (event.keyCode == kVK_ANSI_K && event.modifierFlags.contains(.command)) {
             if titleLabel.isEditable {
-                titleLabel.isEditable = false
+                titleLabel.editModeOff()
                 titleLabel.window?.makeFirstResponder(nil)
             }
 
@@ -942,9 +942,7 @@ class ViewController: NSViewController,
         guard let vc = ViewController.shared() else { return }
 
         if vc.notesTableView.selectedRow > -1 {
-            vc.titleLabel.isEditable = true
-            vc.titleLabel.isEnabled = true
-            MainWindowController.shared()?.makeFirstResponder(vc.titleLabel)
+            vc.titleLabel.editModeOn()
             vc.titleBarAdditionalView.alphaValue = 0
             
             if let note = EditTextView.note, note.getFileName().isValidUUID {
@@ -1250,7 +1248,7 @@ class ViewController: NSViewController,
         guard let textField = obj.object as? NSTextField, textField == titleLabel else { return }
         
         if titleLabel.isEditable == true {
-            titleLabel.isEditable = false
+            titleLabel.editModeOff()
             fileName(titleLabel)
             view.window?.makeFirstResponder(notesTableView)
         }


### PR DESCRIPTION
Steps to reproduce:
1. Open a note
2. Press `CMD+R` and change the title
3. Hover mouse cursor over the action buttons view

Expected result:
Action buttons become visible

Actual result:
Action buttons stay hidden