### PR TITLE
Escape backslashes in MathJax example

### DIFF
--- a/Resources/Welcome.bundle/7.textbundle/text.markdown
+++ b/Resources/Welcome.bundle/7.textbundle/text.markdown
@@ -22,5 +22,5 @@ sequenceDiagram
 
 Documentation: https://www.mathjax.org
 
-When $a \ne 0$, there are two solutions to \(ax^2 + bx + c = 0\) and they are
+When $a \ne 0$, there are two solutions to \\(ax^2 + bx + c = 0\\) and they are
 $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$


### PR DESCRIPTION
Currently the \(ax^2 + bx + c = 0\) doesn't render because Markdown escapes backslashes.