### PR TITLE
Only show incomplete todos in the Todo section #793

### DIFF
--- a/FSNotes iOS/ViewController.swift
+++ b/FSNotes iOS/ViewController.swift
@@ -433,10 +433,8 @@ class ViewController: UIViewController, UISearchBarDelegate, UIGestureRecognizer
                 if (
                     !note.name.isEmpty
                         && (
-                            filter.isEmpty && type != .Todo || type == .Todo && (
-                                self.isMatched(note: note, terms: ["- [ ]"])
-                                    || self.isMatched(note: note, terms: ["- [x]"])
-                                )
+                            filter.isEmpty && type != .Todo || type == .Todo
+                                && self.isMatched(note: note, terms: ["- [ ]"])
                                 || self.isMatched(note: note, terms: terms)
                         ) && (
                             self.isFit(note: note, sidebarItem: sidebarItem, filter: filter)

--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -1544,10 +1544,8 @@ class ViewController: NSViewController,
         return !note.name.isEmpty
             && (
                 filter.isEmpty && type != .Todo
-                    || type == .Todo && (
-                        self.isMatched(note: note, terms: ["- [ ]"])
-                            || self.isMatched(note: note, terms: ["- [x]"])
-                    )
+                    || type == .Todo
+                    && self.isMatched(note: note, terms: ["- [ ]"])
                     || self.isMatched(note: note, terms: terms!)
             ) && (
                 type == .All && !note.project.isArchive && note.project.showInCommon


### PR DESCRIPTION
Fixes #793. 

The Todo section on the sidebar currently shows items with Todos regardless of whether all of the Todos are complete or not. This filters it so that once all of the Todos are checked, it will no longer show in the list.

I'd propose that there be a "Done" section on the sidebar if it is useful to show what todos have been finished off (I don't know that that would be useful myself). For now I've left it as is.

![2020-03-01 14 26 49](https://user-images.githubusercontent.com/607938/75632307-c2eb2a80-5bc8-11ea-9ea7-c8e719ea8e47.gif)

Notice how the Todo note is no longer visible in the gif after completing both todo items. It can of course show up in other sections, and it will show back up in the Todo section if you uncheck one of those checkboxes or add a new unchecked one.