### PR TITLE
Standardize tag matching on a single regex

### DIFF
--- a/FSNotes/Business/Note.swift
+++ b/FSNotes/Business/Note.swift
@@ -1223,7 +1223,7 @@ public class Note: NSObject  {
                             return
                         }
                         
-                        if ["/"].contains(cleanTag.last) {
+                        if cleanTag.last == "/" {
                             tags.append(String(cleanTag.dropLast()))
                         } else {
                             tags.append(cleanTag)

--- a/FSNotes/Business/Note.swift
+++ b/FSNotes/Business/Note.swift
@@ -1190,8 +1190,6 @@ public class Note: NSObject  {
         var removed = [String]()
 
         let matchingOptions = NSRegularExpression.MatchingOptions(rawValue: 0)
-        let pattern = "(?:\\A|\\s)\\#([^\\s\\!\\#\\:\\[\\\"\\(\\;\\,\\`]+)"
-
         let options: NSRegularExpression.Options = [
             .allowCommentsAndWhitespace,
             .anchorsMatchLines
@@ -1201,7 +1199,7 @@ public class Note: NSObject  {
 
         do {
             let range = NSRange(location: 0, length: content.length)
-            let re = try NSRegularExpression(pattern: pattern, options: options)
+            let re = try NSRegularExpression(pattern: NotesTextProcessor.tagsPattern, options: options)
 
             re.enumerateMatches(
                 in: content.string,
@@ -1225,7 +1223,7 @@ public class Note: NSObject  {
                             return
                         }
                         
-                        if ["/", "!", "?", ";", ":", ".", ","].contains(cleanTag.last) {
+                        if ["/"].contains(cleanTag.last) {
                             tags.append(String(cleanTag.dropLast()))
                         } else {
                             tags.append(cleanTag)
@@ -1265,8 +1263,6 @@ public class Note: NSObject  {
     private var excludeRanges = [NSRange]()
 
     public func isValid(tag: String) -> Bool {
-        //let isHEX = (tag.matchingStrings(regex: "^[A-Fa-f0-9]{6}$").last != nil)
-        
         if tag.isNumber {
             return false
         }

--- a/FSNotes/Helpers/NotesTextProcessor.swift
+++ b/FSNotes/Helpers/NotesTextProcessor.swift
@@ -392,18 +392,14 @@ public class NotesTextProcessor {
         NotesTextProcessor.tagsInlineRegex.matches(content.string, range: range) { (result) -> Void in
             guard var range = result?.range(at: 1) else { return }
 
-            range = NSRange(location: range.location - 1, length: range.length + 1)
             var substring = attributedString.mutableString.substring(with: range)
+            guard !substring.isNumber else { return }
 
-            substring = substring
+            range = NSRange(location: range.location - 1, length: range.length + 1)
+            substring = attributedString.mutableString.substring(with: range)
                 .replacingOccurrences(of: "#", with: "")
                 .replacingOccurrences(of: "\n", with: "")
                 .trim()
-
-            if ["!", "?", ";", ":", ".", ","].contains(substring.last) {
-                range = NSRange(location: range.location, length: range.length - 1)
-                substring = String(substring.dropLast())
-            }
 
             guard let tag = substring.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else { return }
 
@@ -955,18 +951,14 @@ public class NotesTextProcessor {
         NotesTextProcessor.tagsInlineRegex.matches(string, range: paragraphRange) { (result) -> Void in
             guard var range = result?.range(at: 1) else { return }
 
-            range = NSRange(location: range.location - 1, length: range.length + 1)
             var substring = attributedString.mutableString.substring(with: range)
+            guard !substring.isNumber else { return }
 
-            substring = substring
+            range = NSRange(location: range.location - 1, length: range.length + 1)
+            substring = attributedString.mutableString.substring(with: range)
                 .replacingOccurrences(of: "#", with: "")
                 .replacingOccurrences(of: "\n", with: "")
                 .trim()
-
-            if ["!", "?", ";", ":", ".", ",", "`"].contains(substring.last) {
-                range = NSRange(location: range.location, length: range.length - 1)
-                substring = String(substring.dropLast())
-            }
 
             guard let tag = substring.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else { return }
 
@@ -1311,7 +1303,18 @@ public class NotesTextProcessor {
     
     public static let imageInlineRegex = MarklightRegex(pattern: imageInlinePattern, options: [.allowCommentsAndWhitespace, .dotMatchesLineSeparators])
 
-    fileprivate static let tagsPattern = "(?:\\A|\\s)\\#([^\\s\\!\\#\\:\\[\\\"\\(\\;\\,]+)"
+    public static let tagsPattern = ###"""
+        (?:\A|\s)
+        \#(
+            [^
+                \s          # no whitespace
+                \#          # no hashes
+                ,?!"`';:\.  # no punctuation
+                \\          # no backslash
+                (){}\[\]    # no bracket pairs
+            ]+
+        )
+    """###
 
     public static let tagsInlineRegex = MarklightRegex(pattern: tagsPattern, options: [.allowCommentsAndWhitespace, .anchorsMatchLines])
 


### PR DESCRIPTION
With this change FSNotes is using a single annotated regex which covers a few
more bases like closing brackets, question marks, and apostrophes.

This allowed simplification of some tag-related sanity checks.

I also added checks to avoid highlighting number-only tags.

Before:
<img width="1094" alt="Screenshot 2021-02-23 at 18 53 18" src="https://user-images.githubusercontent.com/55281/108995849-f6f31180-769d-11eb-9ab1-bb057183c47a.png">
<img width="1094" alt="Screenshot 2021-02-23 at 19 11 19" src="https://user-images.githubusercontent.com/55281/108995870-fc505c00-769d-11eb-97b2-45583e4364cc.png">

After:
<img width="1284" alt="Screenshot 2021-02-24 at 12 36 13" src="https://user-images.githubusercontent.com/55281/108995889-02463d00-769e-11eb-852d-47db3ba3ebec.png">

