### PR TITLE
finish: add config whether keep showing original note when click tag

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -2926,6 +2926,17 @@ Italian 🇮🇹</string>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MoP-74-f43">
+                                <rect key="frame" x="40" y="13" width="378" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Keep showing original note when clicking tag" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LWq-lx-lmT">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="originalNote:" target="ssC-ed-19K" id="InP-yj-xKo"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <connections>
@@ -2941,6 +2952,7 @@ Italian 🇮🇹</string>
                         <outlet property="liveImagesPreview" destination="ons-S0-fcz" id="jhA-O4-Jo7"/>
                         <outlet property="marginSize" destination="gl0-rI-S66" id="Apd-uE-KF3"/>
                         <outlet property="markdownCodeTheme" destination="xZA-pB-1nm" id="lkX-04-F8B"/>
+                        <outlet property="originalNote" destination="MoP-74-f43" id="7Fk-Ua-wo3"/>
                         <outlet property="restoreCursorButton" destination="APN-cG-GJc" id="oUp-xe-mh0"/>
                         <outlet property="spacesInsteadTab" destination="SmD-r7-dGK" id="SRs-jA-N48"/>
                     </connections>

--- a/FSNotes/Helpers/UserDefaultsManagement.swift
+++ b/FSNotes/Helpers/UserDefaultsManagement.swift
@@ -122,6 +122,7 @@ public class UserDefaultsManagement {
         static let TextMatchAutoSelection = "textMatchAutoSelection"
         static let AutocloseBrackets = "autocloseBrackets"
         static let Welcome = "welcome"
+        static let OriginalNote = "originalNote"
     }
 
     static var codeFontName: String {
@@ -1455,6 +1456,18 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.LastScreenY)
+        }
+    }
+    
+    static var originalNote: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.OriginalNote) as? Bool {
+                return result
+            }
+            return true
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.OriginalNote)
         }
     }
 }

--- a/FSNotes/Preferences/PreferencesEditorViewController.swift
+++ b/FSNotes/Preferences/PreferencesEditorViewController.swift
@@ -24,6 +24,7 @@ class PreferencesEditorViewController: NSViewController {
     @IBOutlet weak var spacesInsteadTab: NSButton!
     @IBOutlet weak var marginSize: NSSlider!
     @IBOutlet weak var inlineTags: NSButton!
+    @IBOutlet weak var originalNote: NSButton!
 
     override func viewWillAppear() {
         super.viewWillAppear()
@@ -61,6 +62,8 @@ class PreferencesEditorViewController: NSViewController {
         marginSize.floatValue = UserDefaultsManagement.marginSize
 
         inlineTags.state = UserDefaultsManagement.inlineTags ? .on : .off
+        
+        originalNote.state = UserDefaultsManagement.originalNote ? .on : .off
     }
 
     //MARK: global variables
@@ -240,4 +243,9 @@ class PreferencesEditorViewController: NSViewController {
         guard let vc = ViewController.shared() else { return }
         vc.refillEditArea()
     }
+    
+    @IBAction func originalNote(_ sender: NSButton) {
+        UserDefaultsManagement.originalNote = (sender.state == .on)
+    }
+    
 }

--- a/FSNotes/View/SidebarOutlineView.swift
+++ b/FSNotes/View/SidebarOutlineView.swift
@@ -550,7 +550,8 @@ class SidebarOutlineView: NSOutlineView,
                 UserDataService.instance.lastName = item.name
             }
 
-            if !UserDataService.instance.firstNoteSelection {
+            // not render if config keep showing original note
+            if !UserDataService.instance.firstNoteSelection && !UserDefaultsManagement.originalNote{
                 vd.editArea.clear()
                 vd.notesTableView.deselectAll(nil)
             }
@@ -586,14 +587,13 @@ class SidebarOutlineView: NSOutlineView,
                         self.selectNote = nil
                         vd.notesTableView.setSelected(note: note)
                     }
-                } else if UserDataService.instance.firstNoteSelection {
+                }else if !UserDefaultsManagement.originalNote && UserDataService.instance.firstNoteSelection{
                     if let note = vd.notesTableView.noteList.first {
                         DispatchQueue.main.async {
                             vd.selectNullTableRow(note: note)
                             vd.editArea.fill(note: note)
                         }
                     }
-
                     UserDataService.instance.firstNoteSelection = false
                 }
             }

--- a/FSNotes/zh-Hans.lproj/Main.strings
+++ b/FSNotes/zh-Hans.lproj/Main.strings
@@ -873,3 +873,6 @@
 
 /* Class = "NSButtonCell"; title = "Show notes in \"Notes\" and \"Todo\" lists"; ObjectID = "Zzw-01-JH7"; */
 "Zzw-01-JH7.title" = "在\"笔记\"和\"待办事项\"列表中显示备注";
+
+/* Class = "NSButtonCell"; title = "Keep showing original note when clicking tag"; ObjectID = "LWq-lx-lmT"; */
+"LWq-lx-lmT.title" = "点击标签时保持展示已选中的笔记";


### PR DESCRIPTION
I add a config that controls whether keeps showing original note when click tag.

If false : It works like before

If true : When you click a tag on a note or sidebar, the note view will keep showing the original note (that you have opened) instead of clearing the text view or show the first note of notes under a tag.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/23608642/119265946-5ddf8280-bc1b-11eb-9eeb-46b0774bbc87.png">
