### PR TITLE
Minor edits to cellSpacing slider in layout preferences pane

### DIFF
--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1192,9 +1193,9 @@ CA
                                 </connections>
                             </colorWell>
                             <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X4v-hO-tFb">
-                                <rect key="frame" x="232" y="373" width="178" height="19"/>
+                                <rect key="frame" x="232" y="367" width="178" height="28"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" maxValue="65" tickMarkPosition="above" sliderType="linear" id="hkY-Mc-VIz">
+                                <sliderCell key="cell" continuous="YES" alignment="left" maxValue="60" doubleValue="15" tickMarkPosition="above" numberOfTickMarks="5" allowsTickMarkValuesOnly="YES" sliderType="linear" id="hkY-Mc-VIz">
                                     <connections>
                                         <binding destination="feO-BX-gQb" name="value" keyPath="values.cellSpacing" id="Ixh-K9-pnZ"/>
                                     </connections>
@@ -3337,11 +3338,11 @@ Italian 🇮🇹</string>
         <image name="NSLockLockedTemplate" width="14" height="15"/>
         <image name="NSQuickLookTemplate" width="21" height="13"/>
         <image name="NSShareTemplate" width="15" height="17"/>
-        <image name="dockIcon2" width="67" height="67"/>
+        <image name="dockIcon2" width="66.5" height="66.5"/>
         <image name="dockIcon4" width="64" height="64"/>
         <image name="icon" width="1024" height="1024"/>
-        <image name="logoInCircle" width="500" height="500"/>
-        <image name="new_note_button" width="512" height="512"/>
+        <image name="logoInCircle" width="250" height="250"/>
+        <image name="new_note_button" width="256" height="256"/>
         <image name="pin" width="128" height="128"/>
         <image name="prefsAdvanced" width="171" height="171"/>
         <image name="prefsEditor" width="128" height="128"/>

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -52,7 +52,9 @@ class PreferencesUserInterfaceViewController: NSViewController {
 
         hidePreview.state = UserDefaultsManagement.hidePreview ? NSControl.StateValue.on : NSControl.StateValue.off
 
-        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing)
+        // * 15.0 here, and below, because the cellSpacing slider, width 60, is divided
+        // into 4 cells, each width 15. maybe there's a better way to do this?
+        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing) / Double(UserDefaultsManagement.previewFontSize) * 15.0
 
         noteFontColor.color = UserDefaultsManagement.fontColor
         backgroundColor.color = UserDefaultsManagement.bgColor
@@ -96,7 +98,7 @@ class PreferencesUserInterfaceViewController: NSViewController {
         vc.splitView.setPosition(215, ofDividerAt: 0)
 
         UserDefaultsManagement.cellSpacing = 38
-        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing)
+        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing) / Double(UserDefaultsManagement.previewFontSize) * 15.0
         vc.setTableRowHeight()
     }
 
@@ -110,7 +112,7 @@ class PreferencesUserInterfaceViewController: NSViewController {
         vc.splitView.setPosition(145, ofDividerAt: 0)
 
         UserDefaultsManagement.cellSpacing = 12
-        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing)
+        cellSpacing.doubleValue = Double(UserDefaultsManagement.cellSpacing) / Double(UserDefaultsManagement.previewFontSize) * 15.0
 
         vc.setTableRowHeight()
         vc.notesTableView.reloadData()
@@ -151,7 +153,14 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBAction func changeCellSpacing(_ sender: NSSlider) {
         guard let vc = ViewController.shared() else { return }
 
+        //let previewFontSize = Double(UserDefaultsManagement.previewFontSize)
+        //let sliderFraction = sender.doubleValue / previewFontSize
+        //let roundedCellSpacing = round(sliderFraction) * previewFontSize
+        //sender.doubleValue = roundedCellSpacing
 
+        let sliderPos = sender.doubleValue / sender.maxValue * 5.0
+        let newSpacing = sliderPos * Double(UserDefaultsManagement.previewFontSize)
+        UserDefaultsManagement.cellSpacing = Int(newSpacing)
         vc.setTableRowHeight()
     }
 
@@ -177,6 +186,10 @@ class PreferencesUserInterfaceViewController: NSViewController {
         guard let tag = sender.selectedItem?.tag else { return }
 
         UserDefaultsManagement.previewFontSize = tag
+
+        let sliderPos = cellSpacing.doubleValue / cellSpacing.maxValue * 5.0
+        let newSpacing = sliderPos * Double(UserDefaultsManagement.previewFontSize)
+        UserDefaultsManagement.cellSpacing = Int(newSpacing)
 
         guard let vc = ViewController.shared() else { return }
         vc.notesTableView.reloadData()


### PR DESCRIPTION
Hi there! I've been using FSNotes for a while now, and I love it.

Two things in this pull request. First, I noticed that the NSSlider was a bit cut off, which bothered me:

![image](https://user-images.githubusercontent.com/40284/131202764-c6aee960-ba18-4a3e-a3eb-c2b23254e471.png)

Second, I thought the fully variable slider didn't feel right in this context; because it has to do with text display, you'll want to change the spacing in full line increments, rather than by some arbitrary number of pixels.

So, this small pull request fixes the display bug, and also changes the behavior of this slider so it "snaps" to even multiples of the current `previewFontSize`. (It also updates when the `previewFontSize` is changed.)

So, that part of the preferences pane looks like this now:

![image](https://user-images.githubusercontent.com/40284/131202837-411c7c9c-02bc-4291-9301-a5b8622a4b08.png)

If there's anything I can do differently to make this more useful, let me know; I'm happy to take another swing at it.

Thanks for considering this change, and for FSNotes!