### PR TITLE
Only allow the selection of known filetypes in the Import Dialog

### DIFF
--- a/FSNotes/ViewController.swift
+++ b/FSNotes/ViewController.swift
@@ -12,6 +12,7 @@ import FSNotesCore_macOS
 import WebKit
 import LocalAuthentication
 import Foundation
+import UniformTypeIdentifiers
 
 class ViewController: NSViewController,
     NSTextViewDelegate,
@@ -1022,6 +1023,11 @@ class ViewController: NSViewController,
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
         panel.canCreateDirectories = false
+        if #available(macOS 11.0, *) {
+            panel.allowedContentTypes = self.storage.allowedExtensions.compactMap{ UTType(tag: $0, tagClass: .filenameExtension, conformingTo: nil) }
+        } else {
+            panel.allowedFileTypes = self.storage.allowedExtensions
+        }
         panel.begin { (result) -> Void in
             if result == NSApplication.ModalResponse.OK {
                 let urls = panel.urls


### PR DESCRIPTION
### Description
Currently it is possible that you can select in the `File -> Import` Dialog all kind of filetypes which could mess up the FSNotes document folder. For example if you select a file which is not supported or if you multiselect a bunch of files and there are unsupported ones in between, all those files would be copied over into the FSNotes folder as well.
This pull request will only allow the selection of files with allowed file extensions.
