### PR TITLE
Bugfix: In func def `unTab`, check for 4 spaces instead of 3

### DIFF
--- a/FSNotes/Helpers/TextFormatter.swift
+++ b/FSNotes/Helpers/TextFormatter.swift
@@ -464,7 +464,7 @@ public class TextFormatter {
 
         if string.starts(with: "\t") {
             padding = 1
-        } else if string.starts(with: "   ") {
+        } else if string.starts(with: "    ") {
             padding = 4
         }
 

--- a/FSNotes/Helpers/TextFormatter.swift
+++ b/FSNotes/Helpers/TextFormatter.swift
@@ -464,7 +464,7 @@ public class TextFormatter {
 
         if string.starts(with: "\t") {
             padding = 1
-        } else if string.starts(with: "    ") {
+        } else if string.starts(with: "   ") {
             padding = 4
         }
 


### PR DESCRIPTION
To reproduce the bug on master, put three spaces in front of a line and press `cmd + [` to untab. Nothing should happen, but the cursor moves to prev line.

Fixed by replacing `"   "` with `"    "`. Assuming it was a typo