### PR TITLE
Side bar bug fixes

### DIFF
--- a/FSNotes iOS/Main.storyboard
+++ b/FSNotes iOS/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -139,7 +139,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZDf-m9-quL">
-                                                    <rect key="frame" x="47" y="16" width="42" height="21"/>
+                                                    <rect key="frame" x="47" y="16" width="118" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -149,6 +149,7 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="ZDf-m9-quL" secondAttribute="trailing" constant="5" id="0lP-PT-79q"/>
                                                 <constraint firstItem="ZDf-m9-quL" firstAttribute="centerY" secondItem="tDd-4m-f4y" secondAttribute="centerY" id="2jK-Iv-hSY"/>
                                                 <constraint firstItem="BML-lv-XMi" firstAttribute="leading" secondItem="tDd-4m-f4y" secondAttribute="leading" constant="15" id="3wN-gR-43e"/>
                                                 <constraint firstItem="ZDf-m9-quL" firstAttribute="leading" secondItem="BML-lv-XMi" secondAttribute="trailing" constant="11" id="WoX-Z4-8rD"/>

--- a/FSNotes iOS/ViewController.swift
+++ b/FSNotes iOS/ViewController.swift
@@ -1247,6 +1247,7 @@ class ViewController: UIViewController, UISearchBarDelegate, UIGestureRecognizer
         UIView.animate(withDuration: 0.2, delay: 0.0, options: .init(), animations: {
             self.notesTableLeadingConstraint.constant = self.maxSidebarWidth
             self.sidebarTableLeadingConstraint.constant = 0
+            self.sidebarTableWidth.constant = self.maxSidebarWidth
             self.view.layoutIfNeeded()
         }) { _ in
             UserDefaultsManagement.sidebarIsOpened = true


### PR DESCRIPTION
Fixes:
1. Adds truncation behaviour for long folder names.
 Steps to reproduce:
a. Add a very long name for folder
b. Folder name is not truncating
 
<img width="170" alt="Screenshot 2023-06-02 at 8 17 53 PM" src="https://github.com/glushchenko/fsnotes/assets/32197474/c1fa8df3-7d14-4444-9407-09aa833d1b33">

2. Updates side bar width to appropriate size on first launch.
Steps to reproduce:
a. Open fsNotes (make sure side bar is closed and atleast one folder has a long name)
b. Open side bar
c. Tap on folder which has long name (can tap on any folder)
d. Side bar wil adjust after you tap: Issue*
https://github.com/glushchenko/fsnotes/assets/32197474/985b7699-21e6-4b4e-adff-e38fb7007058
