### PR TITLE
Fix of UI Glitch on iOS #1530

### DIFF
--- a/FSNotes iOS/View/SidebarTableView.swift
+++ b/FSNotes iOS/View/SidebarTableView.swift
@@ -136,9 +136,12 @@ class SidebarTableView: UITableView,
 
         selectRow(at: indexPath, animated: false, scrollPosition: .none)
         vc.configureNavMenu(for: sidebarItem)
+        
+        guard vc.searchQuery.project != newQuery.project else { return }
 
         vc.reloadNotesTable(with: newQuery) {
             DispatchQueue.main.async {
+                
                 vc.setNavTitle(folder: name)
 
                 guard vc.notesTable.notes.count > 0 else {

--- a/FSNotes iOS/View/SidebarTableView.swift
+++ b/FSNotes iOS/View/SidebarTableView.swift
@@ -137,11 +137,9 @@ class SidebarTableView: UITableView,
 
         selectRow(at: indexPath, animated: false, scrollPosition: .none)
         vc.configureNavMenu(for: sidebarItem)
-        
 
         vc.reloadNotesTable(with: newQuery) {
             DispatchQueue.main.async {
-                
                 vc.setNavTitle(folder: name)
 
                 guard vc.notesTable.notes.count > 0 else {

--- a/FSNotes iOS/View/SidebarTableView.swift
+++ b/FSNotes iOS/View/SidebarTableView.swift
@@ -84,6 +84,7 @@ class SidebarTableView: UITableView,
         guard sidebar.items.indices.contains(indexPath.section) && sidebar.items[indexPath.section].indices.contains(indexPath.row) else { return }
 
         let sidebarItem = sidebar.items[indexPath.section][indexPath.row]
+        guard vc.searchQuery.project != sidebarItem.project else { return }
 
         if let project = vc.searchQuery.project, getIndexPathBy(project: project) == indexPath, vc.notesTable.isEditing {
             vc.notesTable.toggleSelectAll()
@@ -137,7 +138,6 @@ class SidebarTableView: UITableView,
         selectRow(at: indexPath, animated: false, scrollPosition: .none)
         vc.configureNavMenu(for: sidebarItem)
         
-        guard vc.searchQuery.project != newQuery.project else { return }
 
         vc.reloadNotesTable(with: newQuery) {
             DispatchQueue.main.async {


### PR DESCRIPTION
https://github.com/glushchenko/fsnotes/issues/1530

### Description

The glitch appears because on folder selection we reload tags list [here](https://github.com/glushchenko/fsnotes/blob/d5e37c2fb2f1d840fe56c5e85666eb84db6178c2/FSNotes%20iOS/View/SidebarTableView.swift#L140)

Added check if a user taps on the selected folder, if yes don't reload notes. 
(On the screencast I tap on the selected folder and glitch doesn't appear)
![Simulator Screen Recording - iPhone 14 - 2023-06-29 at 23 22 13](https://github.com/glushchenko/fsnotes/assets/2940891/893e71ab-c4aa-4cea-b0bd-e3d5b43920ab)

The changes also fix another glitch when a user taps on the current project, notes list blinks
![Simulator Screen Recording - iPhone 14 - 2023-06-29 at 23 28 34](https://github.com/glushchenko/fsnotes/assets/2940891/c5796c92-6840-4796-b966-b9582ff9cc14)


