### PR TITLE
Rename folder bug fix

### DIFF
--- a/FSNotes iOS/View/SidebarTableView.swift
+++ b/FSNotes iOS/View/SidebarTableView.swift
@@ -55,10 +55,6 @@ class SidebarTableView: UITableView,
             return 5
         }
 
-        if section == 1 && UIApplication.getVC().storage.getNonSystemProjects().count == 0 {
-            return 0
-        }
-
         return 25
     }
 


### PR DESCRIPTION
Removed header height to zero code. When we were renaming a folder which will impact the `first folder` of in the sorted order, height of header was getting reduced to zero.

e.g. say we have two folders:
Folder_1 : B
Folder_2: C

Now if we rename Folder_2 to A, then height of header was getting reduced to zero which caused the issue. 

Attaching a videos for the reference:
Fixes:  [#1573](https://github.com/glushchenko/fsnotes/issues/1573)

https://github.com/glushchenko/fsnotes/assets/32197474/367b1d5d-b4f8-42e0-9f6b-38dcf0df94b1

