### PR TITLE
Added support for variables in Soulver

### DIFF
--- a/FSNotes/Business/Markdown.swift
+++ b/FSNotes/Business/Markdown.swift
@@ -43,7 +43,11 @@ func renderMarkdownHTML(markdown: String) -> String? {
 }
 
 func renderSoulverCodeBlocks(markdown: String) -> String {
-    let calculator = Calculator(customization: .standard)
+
+    var customization: EngineCustomization = .standard
+    customization.featureFlags.variableDeclarations = true /// Add the variable declarations feature
+    let calculator = Calculator(customization: customization) /// Use this customization with a new Calculator object
+
     let content = NSMutableAttributedString(string: markdown)
     var update = [String: String]()
 


### PR DESCRIPTION
Hi @glushchenko! Thank you for your amazing work on this project 🙌 

I'm not sure about contribution guidelines, but I'd like to propose this change to Soulver functionality. This change allows to use variables through Soulver expressions, so one can write:
```
{trip_total = 200usd + 300euro + 100pln in usd to 2 dp}
{people = 4}
{cost_per_person = trip_total / people to 2 dp}
```

and get:
```
$543,18
4
$135,80
```

This change is not very invasive so I think you can consider this as a default. If you think otherwise I'd by happy to move it to the settings. Let me know what you think!