### PR TITLE
Fix "markdwon" typo in Info plist

### DIFF
--- a/FSNotes Info (Notarized).plist
+++ b/FSNotes Info (Notarized).plist
@@ -251,7 +251,7 @@
 				<string>public.plain-text</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>Markdwon</string>
+			<string>Markdown</string>
 			<key>UTTypeIconFile</key>
 			<string>Markdown</string>
 			<key>UTTypeIdentifier</key>

--- a/FSNotes/Info.plist
+++ b/FSNotes/Info.plist
@@ -251,7 +251,7 @@
 				<string>public.plain-text</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>Markdwon</string>
+			<string>Markdown</string>
 			<key>UTTypeIconFile</key>
 			<string>Markdown</string>
 			<key>UTTypeIdentifier</key>


### PR DESCRIPTION
Simple typo fix.  Currently the typo appears in Finder under the "Kind" heading like so:

<img width="406" alt="Screenshot 2024-03-28 at 19 35 09" src="https://github.com/glushchenko/fsnotes/assets/107308/192b78aa-178b-405b-a4ab-94137b0405ef">
