### PR TITLE
Remove sidebar item tint

### DIFF
--- a/FSNotes/Business/SidebarItemType.swift
+++ b/FSNotes/Business/SidebarItemType.swift
@@ -46,17 +46,9 @@ enum SidebarItemType: Int {
 #if os(OSX)
     public func getIcon(white: Bool = false) -> NSImage? {
         guard let icon = icon else { return nil }
-
         let image = NSImage(named: icon)
         image?.isTemplate = true
-
-        if UserDefaults.standard.value(forKey: "AppleAccentColor") != nil {
-            return image?.tint(color: NSColor.controlAccentColor)
-        } else if white && !NSAppearance.current.isDark {
-            return image?.tint(color: .white)
-        } else {
-            return image?.tint(color: NSColor(red: 0.08, green: 0.60, blue: 0.85, alpha: 1.00))
-        }
+        return image
     }
 #else
     public func getIcon() -> UIImage? {


### PR DESCRIPTION
On macOS 14.5, the tint function here doesn't effect the image color. Even if I return `image.tint(color: .red)`, it always shows the system accent color. So we can just return `image` and remove the custom tinting, since it doesn't seem to do anything anyways