### PR TITLE
The 'Autoname by Title' feature is now more reliable.

### DIFF
--- a/FSNotes/Business/Note.swift
+++ b/FSNotes/Business/Note.swift
@@ -2300,7 +2300,7 @@ public class Note: NSObject  {
             return nil
         }
         
-        if UserDefaultsManagement.naming == .autoRenameNew && isOlderThanOneDay(from: creationDate) {
+        if UserDefaultsManagement.naming == .autoRenameNew && isOlderThanThirtySeconds(from: creationDate) {
             return nil
         }
 
@@ -2337,13 +2337,14 @@ public class Note: NSObject  {
         return project.getNestedPath() + "/" + name
     }
     
-    func isOlderThanOneDay(from date: Date? = nil) -> Bool {
-        if let date = date, let differenceInDays = Calendar.current.dateComponents([.day], from: date, to: Date()).day {
-            return differenceInDays >= 1
-        }
-        
-        return false
+func isOlderThanThirtySeconds(from date: Date? = nil) -> Bool {
+if let date = date {
+    let differenceInSeconds = Int(Date().timeIntervalSince(date))
+    return differenceInSeconds >= 30 
     }
+
+    return false
+}
     
     public func loadPreviewState() {
         previewState = project.settings.notesPreview.contains(name)


### PR DESCRIPTION
**Autoname by Title** now assigns a file name only within the first 30 seconds of the file creation. Once a file name has been assigned (manually or automatically), modification of the first line of the text doesn't trigger a change in the file name. It is **autoname**, on purpose. 
If the user wants the modification of the first line to trigger a change on the file name, she/he can choose the "Autorename" option. "