### PR TITLE
iOS: Do not treat "no changes" as a Git error when the user syncs

### DIFF
--- a/FSNotes iOS/View/NotesTableView.swift
+++ b/FSNotes iOS/View/NotesTableView.swift
@@ -864,6 +864,16 @@ class NotesTableView: UITableView,
                 DispatchQueue.main.async {
                     nvc.dismiss(animated: false, completion: nil)
                 }
+            } catch GitError.noAddedFiles {
+                DispatchQueue.main.async {
+                    // Hide loader
+                    nvc.dismiss(animated: false, completion: nil)
+
+                    let alert = UIAlertController(title: "No changes", message: "Nothing new to commit", preferredStyle: UIAlertController.Style.alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
+
+                    nvc.present(alert, animated: true, completion: nil)
+                }
             } catch {
                 DispatchQueue.main.async {
                     // Hide loader


### PR DESCRIPTION
When the user presses the "Git Add/commit/push" action and there are no changes to commit, currently a scary "GitError 12" modal shows.

With this change, the modal says what is actually happening: no changes to commit.