### PR TITLE
iOS: Suspend the Git queue until all notes are initially loaded

### DIFF
--- a/FSNotes iOS/ViewController.swift
+++ b/FSNotes iOS/ViewController.swift
@@ -141,6 +141,7 @@ class ViewController: UIViewController, UISearchBarDelegate, UIGestureRecognizer
         
         gitQueue.qualityOfService = .userInteractive
         gitQueue.maxConcurrentOperationCount = 1
+        gitQueue.isSuspended = true
 
         gitQueueState.qualityOfService = .background
         gitQueueState.maxConcurrentOperationCount = 1
@@ -458,6 +459,7 @@ class ViewController: UIViewController, UISearchBarDelegate, UIGestureRecognizer
         let projects = storage.getProjects()
         
         for project in projects {
+            print("Reading project \(project.label) (\(project.url))")
             _ = project.loadNotes()
         }
         
@@ -500,6 +502,8 @@ class ViewController: UIViewController, UISearchBarDelegate, UIGestureRecognizer
                 // enable iCloud Drive updates after projects structure formalized
                 self.cloudDriveManager?.metadataQuery.enableUpdates()
                 self.isLoadedDB = true
+
+                self.gitQueue.isSuspended = false
             }
         }
     }

--- a/FSNotes/Business/Storage.swift
+++ b/FSNotes/Business/Storage.swift
@@ -556,7 +556,7 @@ class Storage {
         if !noteList.contains(where: { $0.name == note.name && $0.project == note.project }) {
            noteList.append(note)
         } else {
-            print("Note exist: \(note.name)")
+            print("Note already exists: \(note.name) (\(note.url))")
         }
     }
 


### PR DESCRIPTION
Fixes #1812.

The problem here was that `ViewController.loadDB()` can take quite a lot of time on the first run. At the same time, the `didBecomeActive()` iOS event was called, which scheduled a git pull task on a thread. This made the `checkNotesCacheDiff()` claim that no notes are known to the app yet, while those same notes were being loaded from the local file system.

This even lead to crashes every now and again due to thread safety issues with reference counting. Making sure that the git queue isn't interrupting the initial load fixes the problem entirely.