### PR TITLE
Do not use dark mode when building print preview

### DIFF
--- a/FSNotes/View/MPreviewView.swift
+++ b/FSNotes/View/MPreviewView.swift
@@ -495,7 +495,7 @@ class MPreviewView: WKWebView, WKUIDelegate, WKNavigationDelegate {
         }
 #else
         platform = "macos"
-        if UserDataService.instance.isDark && archivePath == nil {
+        if UserDataService.instance.isDark && archivePath == nil && print == false {
             appearance = "darkmode"
         }
 #endif


### PR DESCRIPTION
# TODO

- [ ] Do not use dark mode when printing the web preview (Fix an issue where printing the note is in in Dark mode if dark macOS theme is used)
