### PR TITLE
Alter table font colour contrast in dark mode

### DIFF
--- a/Resources/MPreview.bundle/index.html
+++ b/Resources/MPreview.bundle/index.html
@@ -47,7 +47,7 @@
         function switchToDarkMode(background) {
             var darkModeStyleElement = document.getElementById(darkModeStylesNodeID);
             if (darkModeStyleElement == null) {
-                var darkModeStyles = "* { color: white; } body { background: " + background + "; } a { color: #98e7a7 } table { border-color: red } table td, table th { background: #908D8D; border-color: black; } table td, table th, table td *, table th * { color: black }; input[type='checkbox] { accent-color: white }";
+                var darkModeStyles = "* { color: white; } body { background: " + background + "; } a { color: #98e7a7 } table { border-color: red } table td, table th { background: #908D8D; border-color: black; } table td, table th, table td *, table th * { color: white }; input[type='checkbox] { accent-color: white }";
                 addStyleString(darkModeStyles, darkModeStylesNodeID);
             }
         }


### PR DESCRIPTION
## Description

Table font colours are the too dark in dark mode, therefore readability is lower than it should be. This minor change raises the readability of items that are drawn inside table in dark mode. There should be no impact in light mode.

## Screenshots

Before:

<img width="485" alt="Screenshot 2025-06-06 at 14 08 52" src="https://github.com/user-attachments/assets/79509abf-d7e1-405a-856d-74b2138ea69b" />

After:

<img width="482" alt="Screenshot 2025-06-06 at 14 10 00" src="https://github.com/user-attachments/assets/840178c7-7fe1-4983-8882-dcf8ba882d9e" />

