### PR TITLE
fix: pinned notes getting lost in iCloud build

### DIFF
--- a/FSNotesCore/Business/Project.swift
+++ b/FSNotesCore/Business/Project.swift
@@ -310,8 +310,6 @@ public class Project: NSObject {
             print("From disk: \(notes.count), lbl: \(label)")
         }
 
-        loadPins(for: notes)
-
         for note in notes {
             storage.add(note)
         }
@@ -357,22 +355,6 @@ public class Project: NSObject {
         }
     }
 
-    public func loadPins(for notes: [Note]) {
-    #if CLOUD_RELATED_BLOCK
-        for note in notes {
-            note.isPinned = false
-        }
-        
-        let store = NSUbiquitousKeyValueStore.default
-        let names = store.array(forKey: "co.fluder.fsnotes.pins.shared") as? [String] ?? []
-        let pinned = Set(names)
-        
-        for note in notes {
-            note.isPinned = pinned.contains(note.getRelatedPath())
-        }
-    #endif
-    }
-    
     func fileExist(fileName: String, ext: String) -> Bool {        
         let fileURL = url.appendingPathComponent(fileName + "." + ext)
 

--- a/FSNotesCore/Business/Storage.swift
+++ b/FSNotesCore/Business/Storage.swift
@@ -122,6 +122,8 @@ class Storage {
 
         loadProjectRelations()
         
+        loadPins(notes: noteList)
+        
         plainWriter.maxConcurrentOperationCount = 1
         plainWriter.qualityOfService = .userInteractive
 
@@ -865,6 +867,8 @@ class Storage {
         for note in notes {
             if names.contains(note.getRelatedPath()) {
                 note.addPin(cloudSave: false)
+            } else {
+                note.removePin(cloudSave: false)
             }
         }
         #endif
@@ -1183,6 +1187,7 @@ class Storage {
             removeNotes.append(contentsOf: append)
         }
 
+        loadPins(notes: insertNotes)
 
         return (remove, insert, removeNotes, insertNotes)
     }


### PR DESCRIPTION
When loading notes through Storage.loadInboxAndTrash(), some pinned notes were getting lost, because we were attempting to check each note's pinned status in iCloud before calling Storage.loadProjectRelations(). Checking for a note's pinned status in iCloud relies on note.getRelatedPath() to get the related path of the note, but without the project relations, this path may be wrong because project.parent may still be incorrectly null.

Fix this issue by updating Storage.loadInboxAndTrash() to update the pinned status after all the projects are loaded and after project relations have been estalished.

Now Project.loadNotes() no longer calls loadPins() to load the pins. Rather, it is the responsbility of the caller to check the pin status by explicitly calling Storage.loadPins() with the notes. This means that Storage.getProjectDiffs() now calls Storage.loadPins() for inserted notes.

Removed Project.loadPins() and updated Storage.loadPins() to clear the pin status for any notes that are no longer pinned in iCloud.

Fixes #1903