### PR TITLE
Fix: YAML frontmatter breaks GFM table rendering in preview

### DIFF
--- a/FSNotesCore/Business/Note.swift
+++ b/FSNotesCore/Business/Note.swift
@@ -824,67 +824,68 @@ public class Note: NSObject  {
         var extractedTitle = String()
         var author = String()
         var date = String()
-        
+
         if (content.hasPrefix("---\n")) {
-            var list = content.components(separatedBy: "---")
-            
-            if (list.count > 2) {
-                let headerList = list[1].components(separatedBy: "\n")
+            let searchStart = content.index(content.startIndex, offsetBy: 4)
+
+            if let closingRange = content.range(of: "\n---\n", range: searchStart..<content.endIndex) {
+                let yamlBlock = String(content[searchStart..<closingRange.lowerBound])
+                let remainingContent = String(content[closingRange.upperBound...])
+
+                let headerList = yamlBlock.components(separatedBy: "\n")
                 for header in headerList {
                     if header.hasPrefix("title:") {
                         extractedTitle = header.replacingOccurrences(of: "title:", with: "").trim()
-                        
+
                         if extractedTitle.hasPrefix("\"") && extractedTitle.hasSuffix("\""){
                             extractedTitle = String(extractedTitle.dropFirst(1))
                             extractedTitle = String(extractedTitle.dropLast(1))
                         }
                     }
-                    
+
                     if header.hasPrefix("author:") {
                         author = header.replacingOccurrences(of: "author:", with: "").trim()
-                        
+
                         if author.hasPrefix("\"") && author.hasSuffix("\""){
                             author = String(author.dropFirst(1))
                             author = String(author.dropLast(1))
                         }
                     }
-                    
+
                     if header.hasPrefix("date:") {
                         date = header.replacingOccurrences(of: "date:", with: "").trim()
-                        
+
                         if date.hasPrefix("\"") && date.hasSuffix("\""){
                             date = String(date.dropFirst(1))
                             date = String(date.dropLast(1))
                         }
                     }
                 }
-                
-                list.removeSubrange(Range(0...1))
-                
+
                 var result = String()
-                
+
                 if (extractedTitle.count > 0) {
                     result = "<h1 class=\"no-border\">" + extractedTitle + "</h1>\n\n"
                 }
-                
+
                 if (author.count > 0) {
                     result += "_" + author + "_\n\n"
                 }
-                
+
                 if (date.count > 0) {
                     result += "_" + date + "_\n\n"
                 }
-                
+
                 if result.count > 0 {
                     result += "<hr>\n\n"
                 }
-                
-                result += list.joined()
-                
+
+                result += remainingContent
+
                 return result
             }
         }
-        
+
         return content
     }
     


### PR DESCRIPTION
## Summary

`cleanMetaData()` uses `content.components(separatedBy: "---")` to strip YAML frontmatter, but this splits the **entire file** on every `---` substring — not just the frontmatter delimiters. When the parts are reassembled with `list.joined()` (no separator), all `---` in the post-frontmatter content are silently deleted.

This destroys GFM table delimiter rows (`|---|---|---|` becomes `||||`) and horizontal rules, causing `cmark_gfm` to render tables as plain text in preview mode.

## Steps to reproduce

1. Create a note with YAML frontmatter:
```markdown
---
date: 2026-05-02
---

| Name | Value |
|------|-------|
| Alpha | 1 |
```
2. Open preview mode
3. **Expected**: rendered table
4. **Actual**: table shown as plain text with visible pipes, delimiter row collapsed to `||||`

Notes **without** frontmatter render tables correctly.

## Root cause

`components(separatedBy: "---")` is a naive string split that matches `---` everywhere — inside table delimiter cells (`|---|`), horizontal rules, and any other content containing three consecutive hyphens. The fix uses `range(of: "\n---\n")` to find only the frontmatter closing delimiter, preserving the remaining content intact.

## Screenshots

**Before (broken):**

Table with frontmatter renders as plain text — delimiter row `|---|---|---|` becomes `||||`:

<img width="500" alt="broken" src="https://github.com/user-attachments/assets/placeholder-before">

*(Tables render correctly when frontmatter is removed from the same file.)*