### PR TITLE
Sidebar note counts, note list appearance preferences, and MiniPreview card view

### DIFF
--- a/FSNotes.xcodeproj/project.pbxproj
+++ b/FSNotes.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		D7315ED6215ED95600AB49D4 /* NSAppearance+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7315ED4215ED95600AB49D4 /* NSAppearance+.swift */; };
 		D73290BA2099F0AB0003F647 /* UndoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78678CA2093AE10001A6620 /* UndoData.swift */; };
 		D735E5BD1F2EF66000173215 /* NoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BC1F2EF66000173215 /* NoteCellView.swift */; };
+		1DC0FFEE2F1A000200000002 /* MiniPreviewCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */; };
+		1DC0FFEE2F1A000300000003 /* MiniPreviewCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */; };
 		D735E5BF1F2F001500173215 /* NoteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BE1F2F001500173215 /* NoteRowView.swift */; };
 		D73673A820D10CF2000BA61D /* CloudDriveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73673A720D10CF2000BA61D /* CloudDriveManager.swift */; };
 		D736DDA927B5DD370012ED70 /* EditorSelectionRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D736DDA827B5DD370012ED70 /* EditorSelectionRect.swift */; };
@@ -1065,6 +1067,7 @@
 		D7315ED1215ED15500AB49D4 /* SidebarSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSplitView.swift; sourceTree = "<group>"; };
 		D7315ED4215ED95600AB49D4 /* NSAppearance+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAppearance+.swift"; sourceTree = "<group>"; };
 		D735E5BC1F2EF66000173215 /* NoteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCellView.swift; sourceTree = "<group>"; };
+		1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPreviewCellView.swift; sourceTree = "<group>"; };
 		D735E5BE1F2F001500173215 /* NoteRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRowView.swift; sourceTree = "<group>"; };
 		D73673A720D10CF2000BA61D /* CloudDriveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudDriveManager.swift; sourceTree = "<group>"; };
 		D736DDA827B5DD370012ED70 /* EditorSelectionRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionRect.swift; sourceTree = "<group>"; };
@@ -1886,6 +1889,7 @@
 				1102DDB02EE4C277005029A6 /* EditTextView+Complete.swift */,
 				110E40A32EA039AA00C62F49 /* EditTextView+DragOperation.swift */,
 				11A6A8F92EF06B90005D000A /* EditTextView+MoveLines.swift */,
+				1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */,
 				D735E5BC1F2EF66000173215 /* NoteCellView.swift */,
 				D735E5BE1F2F001500173215 /* NoteRowView.swift */,
 				D7A415131F2FBDA00099B82C /* NotesTableView.swift */,
@@ -2943,6 +2947,7 @@
 				11BD8FA02EDE0235000673A7 /* AtomOneLight.swift in Sources */,
 				11D702AD2E5B8E0C004DBAEC /* HtmlExtractor.swift in Sources */,
 				D7D1DE68216D05A800AC1845 /* NameTextField.swift in Sources */,
+				1DC0FFEE2F1A000200000002 /* MiniPreviewCellView.swift in Sources */,
 				D735E5BF1F2F001500173215 /* NoteRowView.swift in Sources */,
 				D7CA7FD4232652E300E9717A /* PreferencesGitViewController.swift in Sources */,
 				D7CD5CCD21820B7B0009D63B /* UserDefaultsManagement+.swift in Sources */,
@@ -3203,6 +3208,7 @@
 				D73BCCB428EB5EC3008B3BBC /* TagIterator.swift in Sources */,
 				D73BCCDE28EB5EC4008B3BBC /* StatusIterator.swift in Sources */,
 				D73BCCA228EB5EC3008B3BBC /* Wrapper.swift in Sources */,
+				1DC0FFEE2F1A000300000003 /* MiniPreviewCellView.swift in Sources */,
 				D7E81C371F925B5F00416A91 /* NoteRowView.swift in Sources */,
 				110E40A42EA039CE00C62F49 /* EditTextView+DragOperation.swift in Sources */,
 				D772C8852217362C007E440B /* ViewController+Print.swift in Sources */,

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1266,7 +1266,7 @@ CA
             <objects>
                 <viewController title="Layout" id="P2a-yk-5Rx" customClass="PreferencesUserInterfaceViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="GGR-Nj-xCY">
-                        <rect key="frame" x="0.0" y="0.0" width="550" height="446"/>
+                        <rect key="frame" x="0.0" y="0.0" width="550" height="468"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9b2-ti-sGJ">
                                 <rect key="frame" x="20" y="236" width="510" height="5"/>
@@ -1345,6 +1345,16 @@ CA
                                 </buttonCell>
                                 <connections>
                                     <action selector="boldTitles:" target="P2a-yk-5Rx" id="dim-22-act"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mpv-01-chk">
+                                <rect key="frame" x="35" y="57" width="170" height="16"/>
+                                <buttonCell key="cell" type="check" title="MiniPreview note list" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mpv-02-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="miniPreview:" target="P2a-yk-5Rx" id="mpv-03-act"/>
                                 </connections>
                             </button>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="thJ-9r-qKd">
@@ -1469,7 +1479,10 @@ CA
                             <constraint firstItem="Yn6-yP-tkd" firstAttribute="leading" secondItem="Hy2-6l-V6s" secondAttribute="leading" id="BOL-TI-Qnj"/>
                             <constraint firstAttribute="bottom" secondItem="4gq-Ny-8kZ" secondAttribute="bottom" constant="35" id="DAN-1V-Dpo"/>
                             <constraint firstItem="BWu-lt-Hmt" firstAttribute="top" secondItem="9b2-ti-sGJ" secondAttribute="bottom" constant="20" id="H6i-af-SIR"/>
-                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="mpv-01-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="mpv-01-chk" firstAttribute="leading" secondItem="dim-20-chk" secondAttribute="leading" id="mpv-05-lea"/>
+                            <constraint firstItem="mpv-01-chk" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="mpv-04-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mpv-01-chk" secondAttribute="trailing" constant="20" symbolic="YES" id="mpv-06-tra"/>
                             <constraint firstItem="nct-01-cnt" firstAttribute="leading" secondItem="Yn6-yP-tkd" secondAttribute="leading" id="nct-05-lea"/>
                             <constraint firstItem="nct-01-cnt" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="nct-06-top"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nct-01-cnt" secondAttribute="trailing" constant="20" symbolic="YES" id="nct-07-tra"/>
@@ -1530,6 +1543,7 @@ CA
                         <outlet property="textBrightness" destination="dim-03-sld" id="dim-50-out"/>
                         <outlet property="titleFontSize" destination="dim-09-pop" id="dim-51-out"/>
                         <outlet property="boldTitles" destination="dim-20-chk" id="dim-52-out"/>
+                        <outlet property="miniPreview" destination="mpv-01-chk" id="mpv-07-out"/>
                     </connections>
                 </viewController>
                 <customObject id="7Tr-yU-uWi" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1266,7 +1266,7 @@ CA
             <objects>
                 <viewController title="Layout" id="P2a-yk-5Rx" customClass="PreferencesUserInterfaceViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="GGR-Nj-xCY">
-                        <rect key="frame" x="0.0" y="0.0" width="550" height="346"/>
+                        <rect key="frame" x="0.0" y="0.0" width="550" height="446"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9b2-ti-sGJ">
                                 <rect key="frame" x="20" y="236" width="510" height="5"/>
@@ -1327,6 +1327,26 @@ CA
                                     <action selector="firstLineAsTitle:" target="P2a-yk-5Rx" id="xpg-88-OBx"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nct-01-cnt">
+                                <rect key="frame" x="35" y="57" width="200" height="16"/>
+                                <buttonCell key="cell" type="check" title="Show note counts in sidebar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nct-02-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showNoteCounts:" target="P2a-yk-5Rx" id="nct-03-act"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-20-chk">
+                                <rect key="frame" x="35" y="57" width="130" height="16"/>
+                                <buttonCell key="cell" type="check" title="Bold note titles" bezelStyle="regularSquare" imagePosition="left" inset="2" id="dim-21-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="boldTitles:" target="P2a-yk-5Rx" id="dim-22-act"/>
+                                </connections>
+                            </button>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="thJ-9r-qKd">
                                 <rect key="frame" x="20" y="157" width="510" height="5"/>
                             </box>
@@ -1359,6 +1379,51 @@ CA
                                 </popUpButtonCell>
                                 <connections>
                                     <action selector="changePreviewFontSize:" target="P2a-yk-5Rx" id="peK-BX-xIu"/>
+                                </connections>
+                            </popUpButton>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-01-lbl">
+                                <rect key="frame" x="130" y="231" width="147" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Note Title Brightness:" id="dim-02-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-03-sld">
+                                <rect key="frame" x="300" y="231" width="150" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="dim-06-wid"/>
+                                </constraints>
+                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="0.3" maxValue="1" doubleValue="1" sliderType="linear" id="dim-04-slc"/>
+                                <connections>
+                                    <action selector="changeTextBrightness:" target="P2a-yk-5Rx" id="dim-05-act"/>
+                                </connections>
+                            </slider>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-07-lbl">
+                                <rect key="frame" x="175" y="199" width="102" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Title Font Size:" id="dim-08-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-09-pop">
+                                <rect key="frame" x="300" y="195" width="96" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="13" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="13" imageScaling="proportionallyDown" inset="2" selectedItem="dim-15-mi3" id="dim-10-ppc">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <menu key="menu" id="dim-11-mnu">
+                                        <items>
+                                            <menuItem title="11" tag="11" id="dim-13-mi1"/>
+                                            <menuItem title="12" tag="12" id="dim-14-mi2"/>
+                                            <menuItem title="13" state="on" tag="13" id="dim-15-mi3"/>
+                                            <menuItem title="14" tag="14" id="dim-16-mi4"/>
+                                            <menuItem title="16" tag="16" id="dim-17-mi6"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="changeTitleFontSize:" target="P2a-yk-5Rx" id="dim-12-act"/>
                                 </connections>
                             </popUpButton>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BWu-lt-Hmt">
@@ -1404,7 +1469,23 @@ CA
                             <constraint firstItem="Yn6-yP-tkd" firstAttribute="leading" secondItem="Hy2-6l-V6s" secondAttribute="leading" id="BOL-TI-Qnj"/>
                             <constraint firstAttribute="bottom" secondItem="4gq-Ny-8kZ" secondAttribute="bottom" constant="35" id="DAN-1V-Dpo"/>
                             <constraint firstItem="BWu-lt-Hmt" firstAttribute="top" secondItem="9b2-ti-sGJ" secondAttribute="bottom" constant="20" id="H6i-af-SIR"/>
-                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="nct-01-cnt" firstAttribute="leading" secondItem="Yn6-yP-tkd" secondAttribute="leading" id="nct-05-lea"/>
+                            <constraint firstItem="nct-01-cnt" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="nct-06-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nct-01-cnt" secondAttribute="trailing" constant="20" symbolic="YES" id="nct-07-tra"/>
+                            <constraint firstItem="dim-20-chk" firstAttribute="leading" secondItem="nct-01-cnt" secondAttribute="leading" id="dim-41-lea"/>
+                            <constraint firstItem="dim-20-chk" firstAttribute="top" secondItem="nct-01-cnt" secondAttribute="bottom" constant="6" symbolic="YES" id="dim-40-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-20-chk" secondAttribute="trailing" constant="20" symbolic="YES" id="dim-42-tra"/>
+                            <constraint firstItem="dim-01-lbl" firstAttribute="top" secondItem="GN8-Yw-N26" secondAttribute="bottom" constant="16" id="dim-30-top"/>
+                            <constraint firstItem="dim-01-lbl" firstAttribute="trailing" secondItem="GGR-Nj-xCY" secondAttribute="centerX" id="dim-31-tra"/>
+                            <constraint firstItem="dim-03-sld" firstAttribute="leading" secondItem="dim-01-lbl" secondAttribute="trailing" constant="25" id="dim-32-lea"/>
+                            <constraint firstItem="dim-03-sld" firstAttribute="centerY" secondItem="dim-01-lbl" secondAttribute="centerY" id="dim-33-cey"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-03-sld" secondAttribute="trailing" constant="35" id="dim-34-tge"/>
+                            <constraint firstItem="dim-07-lbl" firstAttribute="top" secondItem="dim-01-lbl" secondAttribute="bottom" constant="16" id="dim-35-top"/>
+                            <constraint firstItem="dim-07-lbl" firstAttribute="trailing" secondItem="GGR-Nj-xCY" secondAttribute="centerX" id="dim-36-tra"/>
+                            <constraint firstItem="dim-09-pop" firstAttribute="leading" secondItem="dim-07-lbl" secondAttribute="trailing" constant="25" id="dim-37-lea"/>
+                            <constraint firstItem="dim-09-pop" firstAttribute="firstBaseline" secondItem="dim-07-lbl" secondAttribute="firstBaseline" id="dim-38-bas"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-09-pop" secondAttribute="trailing" constant="35" id="dim-39-tge"/>
                             <constraint firstItem="thJ-9r-qKd" firstAttribute="top" secondItem="ax0-sQ-dzy" secondAttribute="bottom" constant="20" id="ICs-MT-tFX"/>
                             <constraint firstAttribute="trailing" secondItem="9b2-ti-sGJ" secondAttribute="trailing" constant="20" symbolic="YES" id="JeV-Ik-fQo"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="h8R-h7-V5R" secondAttribute="trailing" constant="35" id="KPN-gr-sZx"/>
@@ -1416,7 +1497,7 @@ CA
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BWu-lt-Hmt" secondAttribute="trailing" constant="251" id="Tjz-rm-KA4"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FFS-iV-L6i" secondAttribute="trailing" constant="20" symbolic="YES" id="UYU-pg-OGA"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hy2-6l-V6s" secondAttribute="trailing" constant="20" symbolic="YES" id="VBP-ry-ssb"/>
-                            <constraint firstItem="9b2-ti-sGJ" firstAttribute="top" secondItem="h8R-h7-V5R" secondAttribute="bottom" constant="20" id="Vby-Rc-07A"/>
+                            <constraint firstItem="9b2-ti-sGJ" firstAttribute="top" secondItem="dim-09-pop" secondAttribute="bottom" constant="20" id="Vby-Rc-07A"/>
                             <constraint firstItem="X4v-hO-tFb" firstAttribute="leading" secondItem="MAi-TG-JXR" secondAttribute="trailing" constant="25" id="cJK-rm-4cP"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Yn6-yP-tkd" secondAttribute="trailing" constant="20" symbolic="YES" id="eSt-TT-Z2A"/>
                             <constraint firstItem="kBX-OV-8sO" firstAttribute="top" secondItem="thJ-9r-qKd" secondAttribute="bottom" constant="20" id="fav-MJ-PDz"/>
@@ -1445,6 +1526,10 @@ CA
                         <outlet property="previewFontSize" destination="h8R-h7-V5R" id="yTV-Pf-FSJ"/>
                         <outlet property="showDockIcon" destination="BWu-lt-Hmt" id="ttK-Oh-uLh"/>
                         <outlet property="showInMenuBar" destination="ax0-sQ-dzy" id="vW6-kA-hRk"/>
+                        <outlet property="showNoteCounts" destination="nct-01-cnt" id="nct-04-out"/>
+                        <outlet property="textBrightness" destination="dim-03-sld" id="dim-50-out"/>
+                        <outlet property="titleFontSize" destination="dim-09-pop" id="dim-51-out"/>
+                        <outlet property="boldTitles" destination="dim-20-chk" id="dim-52-out"/>
                     </connections>
                 </viewController>
                 <customObject id="7Tr-yU-uWi" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1545,7 +1630,7 @@ CA
                                                                                 <constraint firstItem="kTp-qw-RCd" firstAttribute="leading" secondItem="1dd-W4-MiY" secondAttribute="trailing" constant="5" id="bav-Au-PqY"/>
                                                                                 <constraint firstItem="kTp-qw-RCd" firstAttribute="centerY" secondItem="I0q-sX-uBq" secondAttribute="centerY" id="fox-W9-Kiy"/>
                                                                                 <constraint firstItem="1dd-W4-MiY" firstAttribute="centerY" secondItem="I0q-sX-uBq" secondAttribute="centerY" id="slG-ke-sdb"/>
-                                                                                <constraint firstAttribute="trailing" secondItem="kTp-qw-RCd" secondAttribute="trailing" constant="3" id="uQs-RT-dHB"/>
+                                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kTp-qw-RCd" secondAttribute="trailing" constant="3" id="uQs-RT-dHB"/>
                                                                             </constraints>
                                                                             <connections>
                                                                                 <outlet property="icon" destination="1dd-W4-MiY" id="cb4-9r-kd2"/>

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -19,10 +19,14 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBOutlet weak var horizontalOrientation: NSButton!
     @IBOutlet weak var showDockIcon: NSButton!
     @IBOutlet weak var showInMenuBar: NSButton!
+    @IBOutlet weak var showNoteCounts: NSButton!
+    @IBOutlet weak var textBrightness: NSSlider!
+    @IBOutlet weak var titleFontSize: NSPopUpButton!
+    @IBOutlet weak var boldTitles: NSButton!
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 460)
+        preferredContentSize = NSSize(width: 550, height: 560)
     }
 
     override func viewDidAppear() {
@@ -44,7 +48,15 @@ class PreferencesUserInterfaceViewController: NSViewController {
         hideDate.state = UserDefaultsManagement.hideDate ? .on : .off
 
         firstLineAsTitle.state = UserDefaultsManagement.firstLineAsTitle ? .on : .off
-        
+
+        showNoteCounts.state = UserDefaultsManagement.showNoteCountsInSidebar ? .on : .off
+
+        textBrightness.doubleValue = UserDefaultsManagement.notesListTextBrightness
+
+        titleFontSize.selectItem(withTag: UserDefaultsManagement.noteTitleFontSize)
+
+        boldTitles.state = UserDefaultsManagement.boldNoteTitles ? .on : .off
+
         horizontalOrientation.state =
             UserDefaultsManagement
             .horizontalOrientation ? .on : .off
@@ -81,6 +93,36 @@ class PreferencesUserInterfaceViewController: NSViewController {
 
     @IBAction func hideDate(_ sender: NSButton) {
         UserDefaultsManagement.hideDate = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func showNoteCounts(_ sender: NSButton) {
+        UserDefaultsManagement.showNoteCountsInSidebar = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+        vc.sidebarOutlineView.reloadData()
+    }
+
+    @IBAction func changeTextBrightness(_ sender: NSSlider) {
+        UserDefaultsManagement.notesListTextBrightness = sender.doubleValue
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func changeTitleFontSize(_ sender: NSPopUpButton) {
+        guard let tag = sender.selectedItem?.tag else { return }
+
+        UserDefaultsManagement.noteTitleFontSize = tag
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func boldTitles(_ sender: NSButton) {
+        UserDefaultsManagement.boldNoteTitles = (sender.state == .on)
 
         guard let vc = ViewController.shared() else { return }
         vc.notesTableView.reloadData()

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -23,10 +23,11 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBOutlet weak var textBrightness: NSSlider!
     @IBOutlet weak var titleFontSize: NSPopUpButton!
     @IBOutlet weak var boldTitles: NSButton!
+    @IBOutlet weak var miniPreview: NSButton!
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 560)
+        preferredContentSize = NSSize(width: 550, height: 582)
     }
 
     override func viewDidAppear() {
@@ -56,6 +57,8 @@ class PreferencesUserInterfaceViewController: NSViewController {
         titleFontSize.selectItem(withTag: UserDefaultsManagement.noteTitleFontSize)
 
         boldTitles.state = UserDefaultsManagement.boldNoteTitles ? .on : .off
+
+        miniPreview.state = UserDefaultsManagement.miniPreview ? .on : .off
 
         horizontalOrientation.state =
             UserDefaultsManagement
@@ -125,6 +128,16 @@ class PreferencesUserInterfaceViewController: NSViewController {
         UserDefaultsManagement.boldNoteTitles = (sender.state == .on)
 
         guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func miniPreview(_ sender: NSButton) {
+        UserDefaultsManagement.miniPreview = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+
+        // Full reload re-queries heightOfRow for every row, so the
+        // card/list switch applies live.
         vc.notesTableView.reloadData()
     }
 

--- a/FSNotes/View/MiniPreviewCellView.swift
+++ b/FSNotes/View/MiniPreviewCellView.swift
@@ -1,0 +1,267 @@
+//
+//  MiniPreviewCellView.swift
+//  FSNotes
+//
+//  Apple Notes-style "card" cell for the notes list (MiniPreview mode).
+//
+//  Fully programmatic subclass of NoteCellView: it creates its own subviews
+//  and assigns them to the inherited outlets (name, preview, date, pin), so
+//  shared call sites (performReload, reloadDate, renderPin) keep working.
+//  The weak image outlets are backed by retained offscreen dummies so shared
+//  code paths never hit nil. NoteCellView.draw() is overridden without a
+//  super call because storyboard-only outlets (titleConstraint) are nil here.
+//
+
+import Cocoa
+
+class MiniPreviewCellView: NoteCellView {
+
+    private let cardView = NSView()
+
+    // Strong backing for the weak inherited image outlets; never displayed.
+    private var offscreenImageViews = [NSImageView]()
+
+    private static let previewFontSize: CGFloat = 10
+    private static let previewLineSpacing: CGFloat = 2
+    private static let previewLines = 8
+    private static let previewMaxChars = 1500
+    private static let cardPadding: CGFloat = 10
+    private static let cardCornerRadius: CGFloat = 8
+    private static let sideMargin: CGFloat = 12
+    private static let cardTopMargin: CGFloat = 6
+    private static let titleSpacing: CGFloat = 8
+    private static let dateSpacing: CGFloat = 2
+    private static let bottomMargin: CGFloat = 10
+    private static let dateFontSize: CGFloat = 11
+
+    public static var cardHeight: CGFloat {
+        let font = NSFont.systemFont(ofSize: previewFontSize)
+        let textHeight = CGFloat(previewLines) * font.lineHeightCustom
+            + CGFloat(previewLines - 1) * previewLineSpacing
+
+        return ceil(textHeight) + cardPadding * 2
+    }
+
+    public static var rowHeight: CGFloat {
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        let titleFont = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        var height = cardTopMargin
+            + cardHeight
+            + titleSpacing
+            + ceil(titleFont.lineHeightCustom)
+
+        if !UserDefaultsManagement.hideDate {
+            let dateFont = NSFont.systemFont(ofSize: dateFontSize)
+            height += dateSpacing + ceil(dateFont.lineHeightCustom)
+        }
+
+        return height + bottomMargin
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupSubviews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupSubviews()
+    }
+
+    private func setupSubviews() {
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        cardView.wantsLayer = true
+        cardView.layer?.cornerRadius = MiniPreviewCellView.cardCornerRadius
+        cardView.layer?.masksToBounds = true
+        addSubview(cardView)
+
+        let previewField = PreviewTextField(frame: .zero)
+        configureLabel(previewField)
+        previewField.alignment = .natural
+        previewField.lineBreakMode = .byWordWrapping
+        previewField.cell?.wraps = true
+        previewField.cell?.truncatesLastVisibleLine = true
+        previewField.maximumNumberOfLines = MiniPreviewCellView.previewLines
+        previewField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        previewField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        previewField.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        cardView.addSubview(previewField)
+        preview = previewField
+
+        let titleField = NSTextField(frame: .zero)
+        configureLabel(titleField)
+        titleField.alignment = .center
+        titleField.lineBreakMode = .byTruncatingTail
+        titleField.maximumNumberOfLines = 1
+        addSubview(titleField)
+        name = titleField
+
+        let dateField = NSTextField(frame: .zero)
+        configureLabel(dateField)
+        dateField.alignment = .center
+        dateField.lineBreakMode = .byClipping
+        dateField.maximumNumberOfLines = 1
+        addSubview(dateField)
+        date = dateField
+
+        let pinView = NSImageView(frame: .zero)
+        pinView.translatesAutoresizingMaskIntoConstraints = false
+        pinView.imageScaling = .scaleProportionallyDown
+        pinView.isHidden = true
+        addSubview(pinView)
+        pin = pinView
+
+        let dummies = [NSImageView(), NSImageView(), NSImageView()]
+        offscreenImageViews = dummies
+        imagePreview = dummies[0]
+        imagePreviewSecond = dummies[1]
+        imagePreviewThird = dummies[2]
+
+        let sideMargin = MiniPreviewCellView.sideMargin
+        let cardPadding = MiniPreviewCellView.cardPadding
+
+        NSLayoutConstraint.activate([
+            cardView.topAnchor.constraint(equalTo: topAnchor, constant: MiniPreviewCellView.cardTopMargin),
+            cardView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideMargin),
+            cardView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -sideMargin),
+            cardView.heightAnchor.constraint(equalToConstant: MiniPreviewCellView.cardHeight),
+
+            previewField.topAnchor.constraint(equalTo: cardView.topAnchor, constant: cardPadding),
+            previewField.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: cardPadding),
+            previewField.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -cardPadding),
+            previewField.bottomAnchor.constraint(lessThanOrEqualTo: cardView.bottomAnchor, constant: -cardPadding),
+
+            titleField.topAnchor.constraint(equalTo: cardView.bottomAnchor, constant: MiniPreviewCellView.titleSpacing),
+            titleField.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleField.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: sideMargin + 22),
+            titleField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -(sideMargin + 22)),
+
+            dateField.topAnchor.constraint(equalTo: titleField.bottomAnchor, constant: MiniPreviewCellView.dateSpacing),
+            dateField.centerXAnchor.constraint(equalTo: centerXAnchor),
+            dateField.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: sideMargin),
+            dateField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -sideMargin),
+
+            pinView.trailingAnchor.constraint(equalTo: titleField.leadingAnchor, constant: -4),
+            pinView.centerYAnchor.constraint(equalTo: titleField.centerYAnchor),
+            pinView.widthAnchor.constraint(equalToConstant: 14),
+            pinView.heightAnchor.constraint(equalToConstant: 14)
+        ])
+    }
+
+    private func configureLabel(_ field: NSTextField) {
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.isEditable = false
+        field.isSelectable = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.cell?.isScrollable = false
+    }
+
+    override func configure(note: Note) {
+        super.configure(note: note)
+
+        // renderPin() reads objectValue
+        objectValue = note
+    }
+
+    override func attachHeaders(note: Note) {
+        name.stringValue = note.getTitle() ?? ""
+        date.stringValue = note.getDateForLabel()
+        preview.stringValue = getCardPreviewText(note: note)
+
+        applyCardStyle()
+    }
+
+    // Called by NotesTableView.performReload; card text has its own fixed style.
+    override func applyPreviewStyle() {
+        applyCardStyle()
+    }
+
+    // Intentionally no super call: NoteCellView.draw() touches storyboard-only
+    // outlets (titleConstraint) and re-applies list styling that does not
+    // exist in the card layout.
+    override func draw(_ dirtyRect: NSRect) {
+        applyCardStyle()
+        renderPin()
+        updateCardAppearance()
+    }
+
+    override var backgroundStyle: NSView.BackgroundStyle {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
+    private func getCardPreviewText(note: Note) -> String {
+        var text = String(note.content.string.prefix(MiniPreviewCellView.previewMaxChars))
+
+        // The first line is already shown as the note title below the card
+        if note.getTitle() != nil, UserDefaultsManagement.firstLineAsTitle,
+            let newline = text.firstIndex(of: "\n") {
+            text = String(text[text.index(after: newline)...])
+        }
+
+        return text
+            .stripMarkdownSyntax()
+            .replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
+            .replacingOccurrences(of: "[ \\t]{2,}", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func applyCardStyle() {
+        let previewFont = NSFont.systemFont(ofSize: MiniPreviewCellView.previewFontSize)
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = MiniPreviewCellView.previewLineSpacing
+        paragraph.lineBreakMode = .byTruncatingTail
+
+        preview.attributedStringValue = NSAttributedString(
+            string: preview.stringValue,
+            attributes: [
+                .font: previewFont,
+                .paragraphStyle: paragraph,
+                .foregroundColor: NSColor.labelColor
+            ]
+        )
+        preview.maximumNumberOfLines = MiniPreviewCellView.previewLines
+
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        name.font = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        let brightness = UserDefaultsManagement.notesListTextBrightness
+        if brightness < 1.0 {
+            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
+        } else {
+            name.textColor = .labelColor
+        }
+
+        date.font = NSFont.systemFont(ofSize: MiniPreviewCellView.dateFontSize)
+        date.textColor = .secondaryLabelColor
+        date.isHidden = UserDefaultsManagement.hideDate
+    }
+
+    private func updateCardAppearance() {
+        guard let layer = cardView.layer else { return }
+
+        layer.backgroundColor = NSColor.textColor.withAlphaComponent(0.04).cgColor
+
+        let isRowSelected = (superview as? NSTableRowView)?.isSelected == true
+        if isRowSelected {
+            layer.borderColor = NSColor.controlAccentColor.cgColor
+            layer.borderWidth = 2
+        } else {
+            layer.borderColor = NSColor.separatorColor.cgColor
+            layer.borderWidth = 1
+        }
+    }
+}

--- a/FSNotes/View/NameTextField.swift
+++ b/FSNotes/View/NameTextField.swift
@@ -12,7 +12,8 @@ class NameTextField: NSTextField {
     override func becomeFirstResponder() -> Bool {
         let status = super.becomeFirstResponder()
 
-        self.textColor = NSColor.init(named: "mainText")
+        self.textColor = NSColor.init(named: "mainText")?
+            .withAlphaComponent(CGFloat(UserDefaultsManagement.notesListTextBrightness))
 
         return status
     }

--- a/FSNotes/View/NoteCellView.swift
+++ b/FSNotes/View/NoteCellView.swift
@@ -70,6 +70,18 @@ class NoteCellView: NSTableCellView {
         renderPin()
         name.layer?.zPosition = 1000
 
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        name.font = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        let brightness = UserDefaultsManagement.notesListTextBrightness
+        if brightness < 1.0 {
+            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
+        } else {
+            name.textColor = .labelColor
+        }
+
         if let descriptor = date.font?.fontDescriptor {
             date.font = NSFont.init(descriptor: descriptor, size: 11)
         }

--- a/FSNotes/View/NotesTableView.swift
+++ b/FSNotes/View/NotesTableView.swift
@@ -208,6 +208,10 @@ class NotesTableView: NSTableView,
             note.loadPreviewInfo()
         }
 
+        if UserDefaultsManagement.miniPreview && !UserDefaultsManagement.horizontalOrientation {
+            return MiniPreviewCellView.rowHeight
+        }
+
         if !UserDefaultsManagement.horizontalOrientation
             && !UserDefaultsManagement.hidePreviewImages,
             let urls = note.imageUrl,
@@ -410,6 +414,25 @@ class NotesTableView: NSTableView,
     }
     
     func makeCell(note: Note) -> NoteCellView {
+        if UserDefaultsManagement.miniPreview && !UserDefaultsManagement.horizontalOrientation {
+            let identifier = NSUserInterfaceItemIdentifier(rawValue: "MiniPreviewCellView")
+            let cell: MiniPreviewCellView
+
+            if let reused = makeView(withIdentifier: identifier, owner: self) as? MiniPreviewCellView {
+                cell = reused
+            } else {
+                cell = MiniPreviewCellView(frame: .zero)
+                cell.identifier = identifier
+            }
+
+            cell.imageKeys = []
+            cell.timestamp = nil
+            cell.configure(note: note)
+            cell.attachHeaders(note: note)
+
+            return cell
+        }
+
         let cell = makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "NoteCellView"), owner: self) as! NoteCellView
 
         cell.imageKeys = []
@@ -654,7 +677,12 @@ class NotesTableView: NSTableView,
         
         if let cell = self.view(atColumn: 0, row: i, makeIfNecessary: false) as? NoteCellView {
             cell.date.stringValue = note.getDateForLabel()
-            cell.loadImagesPreview(position: i, urls: urls)
+
+            // MiniPreview cards render no image previews
+            if !(cell is MiniPreviewCellView) {
+                cell.loadImagesPreview(position: i, urls: urls)
+            }
+
             cell.attachHeaders(note: note)
             cell.renderPin()
             cell.applyPreviewStyle()

--- a/FSNotes/View/SidebarCellView.swift
+++ b/FSNotes/View/SidebarCellView.swift
@@ -15,6 +15,52 @@ class SidebarCellView: NSTableCellView {
     public var type: SidebarItemType?
     public var storage = Storage.shared()
 
+    private var countLabel: NSTextField?
+
+    public func updateCount(_ count: Int?) {
+        guard let count = count, UserDefaultsManagement.showNoteCountsInSidebar else {
+            // Do not create the label (and its constraints) for cells that
+            // never showed a count — just reset reused ones.
+            countLabel?.stringValue = ""
+            countLabel?.isHidden = true
+            return
+        }
+
+        let field = countLabel ?? createCountLabel()
+        field.stringValue = String(count)
+        field.isHidden = false
+    }
+
+    private func createCountLabel() -> NSTextField {
+        let field = NSTextField()
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.isEditable = false
+        field.isSelectable = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.backgroundColor = .clear
+        field.alignment = .right
+        field.font = NSFont.systemFont(ofSize: 11)
+        field.textColor = .secondaryLabelColor
+        field.lineBreakMode = .byClipping
+
+        field.setContentHuggingPriority(.required, for: .horizontal)
+        field.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        addSubview(field)
+
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        NSLayoutConstraint.activate([
+            field.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            field.centerYAnchor.constraint(equalTo: label.centerYAnchor),
+            field.leadingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor, constant: 4)
+        ])
+
+        countLabel = field
+        return field
+    }
+
     @IBAction func projectName(_ sender: NSTextField) {
         let cell = sender.superview as? SidebarCellView
 

--- a/FSNotes/View/SidebarOutlineView.swift
+++ b/FSNotes/View/SidebarOutlineView.swift
@@ -457,6 +457,9 @@ class SidebarOutlineView: NSOutlineView,
 
         cell.icon.contentTintColor = NSColor.controlAccentColor
 
+        // Reset possible stale count from a reused cell; project rows set it below.
+        cell.updateCount(nil)
+
         if let tag = item as? FSTag {
             cell.type = .Tag
 
@@ -498,6 +501,8 @@ class SidebarOutlineView: NSOutlineView,
             cell.icon.isHidden = false
             cell.label.frame.origin.x = 25
             cell.textField?.stringValue = project.label
+
+            cell.updateCount(UserDefaultsManagement.showNoteCountsInSidebar ? project.getNotes().count : nil)
 
         } else if let si = item as? SidebarItem {
             let name = si.type == .Separator ? "" : si.name

--- a/FSNotesCore/Extensions/String+.swift
+++ b/FSNotesCore/Extensions/String+.swift
@@ -58,6 +58,44 @@ public extension String {
             .replacingOccurrences(of: "\u{FFFC}", with: "")
     }
 
+    /// Strips common markdown syntax for plain-text display (MiniPreview cards).
+    /// Builds on trimMDSyntax(), additionally handling emphasis markers,
+    /// links, blockquotes, list markers and common HTML entities.
+    func stripMarkdownSyntax() -> String {
+        var result = trimMDSyntax()
+
+        let regexReplacements: [(String, String)] = [
+            ("!\\[([^\\]]*)\\]\\(([^)]*)\\)", "$1"),                 // images -> alt text
+            ("\\[([^\\]]+)\\]\\(([^)]*)\\)", "$1"),                  // links -> link text
+            ("(?m)^\\s{0,3}#{1,6}[ \\t]+", ""),                      // heading markers
+            ("(?m)^\\s{0,3}>[ \\t]?", ""),                           // blockquotes
+            ("(\\*{1,3}|_{1,3}|~~)(?=\\S)(.+?)(?<=\\S)\\1", "$2"),   // bold/italic/strike
+            ("`([^`\\n]+)`", "$1"),                                  // inline code
+            ("(?m)^[ \\t]*([-*_][ \\t]*){3,}$", ""),                 // horizontal rules
+            ("(?m)^\\s*[-+*][ \\t]+", "• "),                        // unordered lists -> bullet
+            ("[*_]{2,}|~~", "")                                      // leftover markers
+        ]
+
+        for (pattern, template) in regexReplacements {
+            result = result.replacingOccurrences(
+                of: pattern,
+                with: template,
+                options: .regularExpression
+            )
+        }
+
+        let entities: [(String, String)] = [
+            ("&quot;", "\""), ("&#34;", "\""), ("&apos;", "'"), ("&#39;", "'"),
+            ("&lt;", "<"), ("&gt;", ">"), ("&nbsp;", " "), ("&amp;", "&")
+        ]
+
+        for (entity, character) in entities {
+            result = result.replacingOccurrences(of: entity, with: character)
+        }
+
+        return result
+    }
+
     func getPrefixMatchSequentially(char: String) -> String? {
         var result = String()
 

--- a/FSNotesCore/UserDefaultsManagement.swift
+++ b/FSNotesCore/UserDefaultsManagement.swift
@@ -118,6 +118,7 @@ public class UserDefaultsManagement {
         static let MarginSizeKey = "marginSize"
         static let MasterPasswordHint = "masterPasswordHint"
         static let MathJaxPreview = "mathJaxPreview"
+        static let MiniPreview = "miniPreview"
         static let NonContiguousLayout = "allowsNonContiguousLayout"
         static let NoteContainer = "noteContainer"
         static let NotesListTextBrightness = "notesListTextBrightness"
@@ -1080,6 +1081,18 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.NotesListTextBrightness)
+        }
+    }
+
+    static var miniPreview: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.MiniPreview) as? Bool {
+                return result
+            }
+            return false
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.MiniPreview)
         }
     }
 

--- a/FSNotesCore/UserDefaultsManagement.swift
+++ b/FSNotesCore/UserDefaultsManagement.swift
@@ -60,6 +60,7 @@ public class UserDefaultsManagement {
         static let BackupManually = "backupManually"
         static let BgColorKey = "bgColorKeyed"
         static let boldKey = "boldKeyed"
+        static let BoldNoteTitles = "boldNoteTitles"
         static let CacheDiff = "cacheDiff"
         static let CellSpacing = "cellSpacing"
         static let CellFrameOriginY = "cellFrameOriginY"
@@ -119,6 +120,8 @@ public class UserDefaultsManagement {
         static let MathJaxPreview = "mathJaxPreview"
         static let NonContiguousLayout = "allowsNonContiguousLayout"
         static let NoteContainer = "noteContainer"
+        static let NotesListTextBrightness = "notesListTextBrightness"
+        static let NoteTitleFontSize = "noteTitleFontSize"
         static let Preview = "preview"
         static let PreviewFontSize = "previewFontSize"
         static let ProjectsKey = "projects"
@@ -142,6 +145,7 @@ public class UserDefaultsManagement {
         static let ShowDockIcon = "showDockIcon"
         static let shouldFocusSearchOnESCKeyDown = "shouldFocusSearchOnESCKeyDown"
         static let ShowInMenuBar = "showInMenuBar"
+        static let ShowNoteCountsInSidebar = "showNoteCountsInSidebar"
         static let SmartInsertDelete = "smartInsertDelete"
         static let SnapshotsInterval = "snapshotsInterval"
         static let SnapshotsIntervalMinutes = "snapshotsIntervalMinutes"
@@ -623,7 +627,19 @@ public class UserDefaultsManagement {
             shared?.set(newValue, forKey: Constants.ShowDockIcon)
         }
     }
-    
+
+    static var showNoteCountsInSidebar: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.ShowNoteCountsInSidebar) as? Bool {
+                return result
+            }
+            return true
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.ShowNoteCountsInSidebar)
+        }
+    }
+
     static var editorLineSpacing: Float {
         get {
             if let result = shared?.object(forKey: Constants.LineSpacingEditorKey) as? Float {
@@ -1028,6 +1044,42 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.FirstLineAsTitle)
+        }
+    }
+
+    static var boldNoteTitles: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.BoldNoteTitles) as? Bool {
+                return result
+            }
+            return false
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.BoldNoteTitles)
+        }
+    }
+
+    static var noteTitleFontSize: Int {
+        get {
+            if let result = shared?.object(forKey: Constants.NoteTitleFontSize) as? NSNumber {
+                return result.intValue
+            }
+            return 13
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.NoteTitleFontSize)
+        }
+    }
+
+    static var notesListTextBrightness: Double {
+        get {
+            if let result = shared?.object(forKey: Constants.NotesListTextBrightness) as? Double {
+                return result
+            }
+            return 1.0
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.NotesListTextBrightness)
         }
     }
 


### PR DESCRIPTION
## What

Three quality-of-life additions for the macOS app, all opt-in/adjustable via the **Layout** preferences pane, with defaults that preserve the current appearance:

### 1. Note counts in the sidebar (Apple Notes style)
Each folder row shows its note count right-aligned in a dim secondary color. The count label is created lazily in `SidebarCellView` (programmatic, 11pt system font, `.secondaryLabelColor`), so tag/system rows never allocate it, and reused cells reset any stale count. Toggleable with a new **Show note counts in sidebar** checkbox (default on).

### 2. Note list appearance preferences
The note title in the list is currently fixed (system regular 13pt, `mainText` / labelColor). This adds:
- **Note list text brightness** slider (0.3–1.0) — applies alpha to the `mainText` color so it works in both light and dark appearance; 1.0 keeps today's exact look
- **Bold note titles** checkbox — `.semibold` title weight (default off)
- **Title font size** popup — 11/12/13/14/16 pt (default 13)

### 3. MiniPreview — Apple Notes style card view for the note list
New **MiniPreview note list** checkbox (default off). When enabled, each note renders as a rounded card containing a markdown-stripped content preview (headings/emphasis/links/code/blockquote markers removed, HTML entities decoded), with a centered title and dim date below — like Apple Notes gallery cards. Selection is shown with an accent card border. Implemented as a fully programmatic `MiniPreviewCellView` reusing the existing cell API, so selection, search, keyboard navigation and context menus keep working; falls back to regular cells in horizontal orientation.

## Notes
- New settings follow the existing `UserDefaultsManagement` patterns (platform-neutral, FSNotesCore)
- Preferences controls follow the existing Layout pane patterns (hideDate, cellSpacing, previewFontSize)
- Storyboard changes validated; built and launched with Xcode 26.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)