### PR TITLE
Sidebar note counts, list/editor appearance preferences, and MiniPreview card view

### DIFF
--- a/FSNotes.xcodeproj/project.pbxproj
+++ b/FSNotes.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		D7315ED6215ED95600AB49D4 /* NSAppearance+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7315ED4215ED95600AB49D4 /* NSAppearance+.swift */; };
 		D73290BA2099F0AB0003F647 /* UndoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78678CA2093AE10001A6620 /* UndoData.swift */; };
 		D735E5BD1F2EF66000173215 /* NoteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BC1F2EF66000173215 /* NoteCellView.swift */; };
+		1DC0FFEE2F1A000200000002 /* MiniPreviewCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */; };
+		1DC0FFEE2F1A000300000003 /* MiniPreviewCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */; };
 		D735E5BF1F2F001500173215 /* NoteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D735E5BE1F2F001500173215 /* NoteRowView.swift */; };
 		D73673A820D10CF2000BA61D /* CloudDriveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73673A720D10CF2000BA61D /* CloudDriveManager.swift */; };
 		D736DDA927B5DD370012ED70 /* EditorSelectionRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D736DDA827B5DD370012ED70 /* EditorSelectionRect.swift */; };
@@ -1065,6 +1067,7 @@
 		D7315ED1215ED15500AB49D4 /* SidebarSplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSplitView.swift; sourceTree = "<group>"; };
 		D7315ED4215ED95600AB49D4 /* NSAppearance+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAppearance+.swift"; sourceTree = "<group>"; };
 		D735E5BC1F2EF66000173215 /* NoteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCellView.swift; sourceTree = "<group>"; };
+		1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPreviewCellView.swift; sourceTree = "<group>"; };
 		D735E5BE1F2F001500173215 /* NoteRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRowView.swift; sourceTree = "<group>"; };
 		D73673A720D10CF2000BA61D /* CloudDriveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudDriveManager.swift; sourceTree = "<group>"; };
 		D736DDA827B5DD370012ED70 /* EditorSelectionRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSelectionRect.swift; sourceTree = "<group>"; };
@@ -1886,6 +1889,7 @@
 				1102DDB02EE4C277005029A6 /* EditTextView+Complete.swift */,
 				110E40A32EA039AA00C62F49 /* EditTextView+DragOperation.swift */,
 				11A6A8F92EF06B90005D000A /* EditTextView+MoveLines.swift */,
+				1DC0FFEE2F1A000100000001 /* MiniPreviewCellView.swift */,
 				D735E5BC1F2EF66000173215 /* NoteCellView.swift */,
 				D735E5BE1F2F001500173215 /* NoteRowView.swift */,
 				D7A415131F2FBDA00099B82C /* NotesTableView.swift */,
@@ -2943,6 +2947,7 @@
 				11BD8FA02EDE0235000673A7 /* AtomOneLight.swift in Sources */,
 				11D702AD2E5B8E0C004DBAEC /* HtmlExtractor.swift in Sources */,
 				D7D1DE68216D05A800AC1845 /* NameTextField.swift in Sources */,
+				1DC0FFEE2F1A000200000002 /* MiniPreviewCellView.swift in Sources */,
 				D735E5BF1F2F001500173215 /* NoteRowView.swift in Sources */,
 				D7CA7FD4232652E300E9717A /* PreferencesGitViewController.swift in Sources */,
 				D7CD5CCD21820B7B0009D63B /* UserDefaultsManagement+.swift in Sources */,
@@ -3203,6 +3208,7 @@
 				D73BCCB428EB5EC3008B3BBC /* TagIterator.swift in Sources */,
 				D73BCCDE28EB5EC4008B3BBC /* StatusIterator.swift in Sources */,
 				D73BCCA228EB5EC3008B3BBC /* Wrapper.swift in Sources */,
+				1DC0FFEE2F1A000300000003 /* MiniPreviewCellView.swift in Sources */,
 				D7E81C371F925B5F00416A91 /* NoteRowView.swift in Sources */,
 				110E40A42EA039CE00C62F49 /* EditTextView+DragOperation.swift in Sources */,
 				D772C8852217362C007E440B /* ViewController+Print.swift in Sources */,

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1266,7 +1266,7 @@ CA
             <objects>
                 <viewController title="Layout" id="P2a-yk-5Rx" customClass="PreferencesUserInterfaceViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="GGR-Nj-xCY">
-                        <rect key="frame" x="0.0" y="0.0" width="550" height="446"/>
+                        <rect key="frame" x="0.0" y="0.0" width="550" height="468"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9b2-ti-sGJ">
                                 <rect key="frame" x="20" y="236" width="510" height="5"/>
@@ -1345,6 +1345,16 @@ CA
                                 </buttonCell>
                                 <connections>
                                     <action selector="boldTitles:" target="P2a-yk-5Rx" id="dim-22-act"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mpv-01-chk">
+                                <rect key="frame" x="35" y="57" width="170" height="16"/>
+                                <buttonCell key="cell" type="check" title="MiniPreview note list" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mpv-02-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="miniPreview:" target="P2a-yk-5Rx" id="mpv-03-act"/>
                                 </connections>
                             </button>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="thJ-9r-qKd">
@@ -1469,7 +1479,10 @@ CA
                             <constraint firstItem="Yn6-yP-tkd" firstAttribute="leading" secondItem="Hy2-6l-V6s" secondAttribute="leading" id="BOL-TI-Qnj"/>
                             <constraint firstAttribute="bottom" secondItem="4gq-Ny-8kZ" secondAttribute="bottom" constant="35" id="DAN-1V-Dpo"/>
                             <constraint firstItem="BWu-lt-Hmt" firstAttribute="top" secondItem="9b2-ti-sGJ" secondAttribute="bottom" constant="20" id="H6i-af-SIR"/>
-                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="mpv-01-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="mpv-01-chk" firstAttribute="leading" secondItem="dim-20-chk" secondAttribute="leading" id="mpv-05-lea"/>
+                            <constraint firstItem="mpv-01-chk" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="mpv-04-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mpv-01-chk" secondAttribute="trailing" constant="20" symbolic="YES" id="mpv-06-tra"/>
                             <constraint firstItem="nct-01-cnt" firstAttribute="leading" secondItem="Yn6-yP-tkd" secondAttribute="leading" id="nct-05-lea"/>
                             <constraint firstItem="nct-01-cnt" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="nct-06-top"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nct-01-cnt" secondAttribute="trailing" constant="20" symbolic="YES" id="nct-07-tra"/>
@@ -1530,6 +1543,7 @@ CA
                         <outlet property="textBrightness" destination="dim-03-sld" id="dim-50-out"/>
                         <outlet property="titleFontSize" destination="dim-09-pop" id="dim-51-out"/>
                         <outlet property="boldTitles" destination="dim-20-chk" id="dim-52-out"/>
+                        <outlet property="miniPreview" destination="mpv-01-chk" id="mpv-07-out"/>
                     </connections>
                 </viewController>
                 <customObject id="7Tr-yU-uWi" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1266,7 +1266,7 @@ CA
             <objects>
                 <viewController title="Layout" id="P2a-yk-5Rx" customClass="PreferencesUserInterfaceViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="GGR-Nj-xCY">
-                        <rect key="frame" x="0.0" y="0.0" width="550" height="346"/>
+                        <rect key="frame" x="0.0" y="0.0" width="550" height="446"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9b2-ti-sGJ">
                                 <rect key="frame" x="20" y="236" width="510" height="5"/>
@@ -1327,6 +1327,26 @@ CA
                                     <action selector="firstLineAsTitle:" target="P2a-yk-5Rx" id="xpg-88-OBx"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nct-01-cnt">
+                                <rect key="frame" x="35" y="57" width="200" height="16"/>
+                                <buttonCell key="cell" type="check" title="Show note counts in sidebar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="nct-02-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showNoteCounts:" target="P2a-yk-5Rx" id="nct-03-act"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-20-chk">
+                                <rect key="frame" x="35" y="57" width="130" height="16"/>
+                                <buttonCell key="cell" type="check" title="Bold note titles" bezelStyle="regularSquare" imagePosition="left" inset="2" id="dim-21-cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="boldTitles:" target="P2a-yk-5Rx" id="dim-22-act"/>
+                                </connections>
+                            </button>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="thJ-9r-qKd">
                                 <rect key="frame" x="20" y="157" width="510" height="5"/>
                             </box>
@@ -1359,6 +1379,51 @@ CA
                                 </popUpButtonCell>
                                 <connections>
                                     <action selector="changePreviewFontSize:" target="P2a-yk-5Rx" id="peK-BX-xIu"/>
+                                </connections>
+                            </popUpButton>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-01-lbl">
+                                <rect key="frame" x="130" y="231" width="147" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Note Title Brightness:" id="dim-02-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-03-sld">
+                                <rect key="frame" x="300" y="231" width="150" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="dim-06-wid"/>
+                                </constraints>
+                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="0.3" maxValue="1" doubleValue="1" sliderType="linear" id="dim-04-slc"/>
+                                <connections>
+                                    <action selector="changeTextBrightness:" target="P2a-yk-5Rx" id="dim-05-act"/>
+                                </connections>
+                            </slider>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-07-lbl">
+                                <rect key="frame" x="175" y="199" width="102" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Title Font Size:" id="dim-08-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dim-09-pop">
+                                <rect key="frame" x="300" y="195" width="96" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="13" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="13" imageScaling="proportionallyDown" inset="2" selectedItem="dim-15-mi3" id="dim-10-ppc">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <menu key="menu" id="dim-11-mnu">
+                                        <items>
+                                            <menuItem title="11" tag="11" id="dim-13-mi1"/>
+                                            <menuItem title="12" tag="12" id="dim-14-mi2"/>
+                                            <menuItem title="13" state="on" tag="13" id="dim-15-mi3"/>
+                                            <menuItem title="14" tag="14" id="dim-16-mi4"/>
+                                            <menuItem title="16" tag="16" id="dim-17-mi6"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="changeTitleFontSize:" target="P2a-yk-5Rx" id="dim-12-act"/>
                                 </connections>
                             </popUpButton>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BWu-lt-Hmt">
@@ -1404,7 +1469,23 @@ CA
                             <constraint firstItem="Yn6-yP-tkd" firstAttribute="leading" secondItem="Hy2-6l-V6s" secondAttribute="leading" id="BOL-TI-Qnj"/>
                             <constraint firstAttribute="bottom" secondItem="4gq-Ny-8kZ" secondAttribute="bottom" constant="35" id="DAN-1V-Dpo"/>
                             <constraint firstItem="BWu-lt-Hmt" firstAttribute="top" secondItem="9b2-ti-sGJ" secondAttribute="bottom" constant="20" id="H6i-af-SIR"/>
-                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="nct-01-cnt" firstAttribute="leading" secondItem="Yn6-yP-tkd" secondAttribute="leading" id="nct-05-lea"/>
+                            <constraint firstItem="nct-01-cnt" firstAttribute="top" secondItem="Yn6-yP-tkd" secondAttribute="bottom" constant="6" symbolic="YES" id="nct-06-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nct-01-cnt" secondAttribute="trailing" constant="20" symbolic="YES" id="nct-07-tra"/>
+                            <constraint firstItem="dim-20-chk" firstAttribute="leading" secondItem="nct-01-cnt" secondAttribute="leading" id="dim-41-lea"/>
+                            <constraint firstItem="dim-20-chk" firstAttribute="top" secondItem="nct-01-cnt" secondAttribute="bottom" constant="6" symbolic="YES" id="dim-40-top"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-20-chk" secondAttribute="trailing" constant="20" symbolic="YES" id="dim-42-tra"/>
+                            <constraint firstItem="dim-01-lbl" firstAttribute="top" secondItem="GN8-Yw-N26" secondAttribute="bottom" constant="16" id="dim-30-top"/>
+                            <constraint firstItem="dim-01-lbl" firstAttribute="trailing" secondItem="GGR-Nj-xCY" secondAttribute="centerX" id="dim-31-tra"/>
+                            <constraint firstItem="dim-03-sld" firstAttribute="leading" secondItem="dim-01-lbl" secondAttribute="trailing" constant="25" id="dim-32-lea"/>
+                            <constraint firstItem="dim-03-sld" firstAttribute="centerY" secondItem="dim-01-lbl" secondAttribute="centerY" id="dim-33-cey"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-03-sld" secondAttribute="trailing" constant="35" id="dim-34-tge"/>
+                            <constraint firstItem="dim-07-lbl" firstAttribute="top" secondItem="dim-01-lbl" secondAttribute="bottom" constant="16" id="dim-35-top"/>
+                            <constraint firstItem="dim-07-lbl" firstAttribute="trailing" secondItem="GGR-Nj-xCY" secondAttribute="centerX" id="dim-36-tra"/>
+                            <constraint firstItem="dim-09-pop" firstAttribute="leading" secondItem="dim-07-lbl" secondAttribute="trailing" constant="25" id="dim-37-lea"/>
+                            <constraint firstItem="dim-09-pop" firstAttribute="firstBaseline" secondItem="dim-07-lbl" secondAttribute="firstBaseline" id="dim-38-bas"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dim-09-pop" secondAttribute="trailing" constant="35" id="dim-39-tge"/>
                             <constraint firstItem="thJ-9r-qKd" firstAttribute="top" secondItem="ax0-sQ-dzy" secondAttribute="bottom" constant="20" id="ICs-MT-tFX"/>
                             <constraint firstAttribute="trailing" secondItem="9b2-ti-sGJ" secondAttribute="trailing" constant="20" symbolic="YES" id="JeV-Ik-fQo"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="h8R-h7-V5R" secondAttribute="trailing" constant="35" id="KPN-gr-sZx"/>
@@ -1416,7 +1497,7 @@ CA
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BWu-lt-Hmt" secondAttribute="trailing" constant="251" id="Tjz-rm-KA4"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FFS-iV-L6i" secondAttribute="trailing" constant="20" symbolic="YES" id="UYU-pg-OGA"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hy2-6l-V6s" secondAttribute="trailing" constant="20" symbolic="YES" id="VBP-ry-ssb"/>
-                            <constraint firstItem="9b2-ti-sGJ" firstAttribute="top" secondItem="h8R-h7-V5R" secondAttribute="bottom" constant="20" id="Vby-Rc-07A"/>
+                            <constraint firstItem="9b2-ti-sGJ" firstAttribute="top" secondItem="dim-09-pop" secondAttribute="bottom" constant="20" id="Vby-Rc-07A"/>
                             <constraint firstItem="X4v-hO-tFb" firstAttribute="leading" secondItem="MAi-TG-JXR" secondAttribute="trailing" constant="25" id="cJK-rm-4cP"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Yn6-yP-tkd" secondAttribute="trailing" constant="20" symbolic="YES" id="eSt-TT-Z2A"/>
                             <constraint firstItem="kBX-OV-8sO" firstAttribute="top" secondItem="thJ-9r-qKd" secondAttribute="bottom" constant="20" id="fav-MJ-PDz"/>
@@ -1445,6 +1526,10 @@ CA
                         <outlet property="previewFontSize" destination="h8R-h7-V5R" id="yTV-Pf-FSJ"/>
                         <outlet property="showDockIcon" destination="BWu-lt-Hmt" id="ttK-Oh-uLh"/>
                         <outlet property="showInMenuBar" destination="ax0-sQ-dzy" id="vW6-kA-hRk"/>
+                        <outlet property="showNoteCounts" destination="nct-01-cnt" id="nct-04-out"/>
+                        <outlet property="textBrightness" destination="dim-03-sld" id="dim-50-out"/>
+                        <outlet property="titleFontSize" destination="dim-09-pop" id="dim-51-out"/>
+                        <outlet property="boldTitles" destination="dim-20-chk" id="dim-52-out"/>
                     </connections>
                 </viewController>
                 <customObject id="7Tr-yU-uWi" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1545,7 +1630,7 @@ CA
                                                                                 <constraint firstItem="kTp-qw-RCd" firstAttribute="leading" secondItem="1dd-W4-MiY" secondAttribute="trailing" constant="5" id="bav-Au-PqY"/>
                                                                                 <constraint firstItem="kTp-qw-RCd" firstAttribute="centerY" secondItem="I0q-sX-uBq" secondAttribute="centerY" id="fox-W9-Kiy"/>
                                                                                 <constraint firstItem="1dd-W4-MiY" firstAttribute="centerY" secondItem="I0q-sX-uBq" secondAttribute="centerY" id="slG-ke-sdb"/>
-                                                                                <constraint firstAttribute="trailing" secondItem="kTp-qw-RCd" secondAttribute="trailing" constant="3" id="uQs-RT-dHB"/>
+                                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kTp-qw-RCd" secondAttribute="trailing" constant="3" id="uQs-RT-dHB"/>
                                                                             </constraints>
                                                                             <connections>
                                                                                 <outlet property="icon" destination="1dd-W4-MiY" id="cb4-9r-kd2"/>

--- a/FSNotes/Base.lproj/Main.storyboard
+++ b/FSNotes/Base.lproj/Main.storyboard
@@ -1266,7 +1266,7 @@ CA
             <objects>
                 <viewController title="Layout" id="P2a-yk-5Rx" customClass="PreferencesUserInterfaceViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="GGR-Nj-xCY">
-                        <rect key="frame" x="0.0" y="0.0" width="550" height="468"/>
+                        <rect key="frame" x="0.0" y="0.0" width="550" height="552"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9b2-ti-sGJ">
                                 <rect key="frame" x="20" y="236" width="510" height="5"/>
@@ -1357,6 +1357,78 @@ CA
                                     <action selector="miniPreview:" target="P2a-yk-5Rx" id="mpv-03-act"/>
                                 </connections>
                             </button>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-01-lbl">
+                                <rect key="frame" x="55" y="33" width="120" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Preview font size:" id="mp2-02-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-03-pop">
+                                <rect key="frame" x="183" y="29" width="96" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="10" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="10" imageScaling="proportionallyDown" inset="2" selectedItem="mp2-07-mi2" id="mp2-04-ppc">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <menu key="menu" id="mp2-05-mnu">
+                                        <items>
+                                            <menuItem title="9" tag="9" id="mp2-06-mi1"/>
+                                            <menuItem title="10" state="on" tag="10" id="mp2-07-mi2"/>
+                                            <menuItem title="11" tag="11" id="mp2-08-mi3"/>
+                                            <menuItem title="12" tag="12" id="mp2-09-mi4"/>
+                                            <menuItem title="14" tag="14" id="mp2-10-mi5"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="changeMiniPreviewFontSize:" target="P2a-yk-5Rx" id="mp2-11-act"/>
+                                </connections>
+                            </popUpButton>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-12-lbl">
+                                <rect key="frame" x="55" y="5" width="120" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Preview lines:" id="mp2-13-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-14-pop">
+                                <rect key="frame" x="183" y="1" width="96" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="8 lines" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="8" imageScaling="proportionallyDown" inset="2" selectedItem="mp2-19-mi3" id="mp2-15-ppc">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <menu key="menu" id="mp2-16-mnu">
+                                        <items>
+                                            <menuItem title="4 lines" tag="4" id="mp2-17-mi1"/>
+                                            <menuItem title="6 lines" tag="6" id="mp2-18-mi2"/>
+                                            <menuItem title="8 lines" state="on" tag="8" id="mp2-19-mi3"/>
+                                            <menuItem title="10 lines" tag="10" id="mp2-20-mi4"/>
+                                            <menuItem title="12 lines" tag="12" id="mp2-21-mi5"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="changeMiniPreviewLines:" target="P2a-yk-5Rx" id="mp2-22-act"/>
+                                </connections>
+                            </popUpButton>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-23-lbl">
+                                <rect key="frame" x="55" y="-23" width="120" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Preview brightness:" id="mp2-24-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mp2-25-sld">
+                                <rect key="frame" x="183" y="-23" width="150" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="mp2-27-wid"/>
+                                </constraints>
+                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="0.3" maxValue="1" doubleValue="1" sliderType="linear" id="mp2-26-slc"/>
+                                <connections>
+                                    <action selector="changeMiniPreviewBrightness:" target="P2a-yk-5Rx" id="mp2-28-act"/>
+                                </connections>
+                            </slider>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="thJ-9r-qKd">
                                 <rect key="frame" x="20" y="157" width="510" height="5"/>
                             </box>
@@ -1479,7 +1551,22 @@ CA
                             <constraint firstItem="Yn6-yP-tkd" firstAttribute="leading" secondItem="Hy2-6l-V6s" secondAttribute="leading" id="BOL-TI-Qnj"/>
                             <constraint firstAttribute="bottom" secondItem="4gq-Ny-8kZ" secondAttribute="bottom" constant="35" id="DAN-1V-Dpo"/>
                             <constraint firstItem="BWu-lt-Hmt" firstAttribute="top" secondItem="9b2-ti-sGJ" secondAttribute="bottom" constant="20" id="H6i-af-SIR"/>
-                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="mpv-01-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="HlI-v1-5rk"/>
+                            <constraint firstItem="4gq-Ny-8kZ" firstAttribute="top" secondItem="mp2-23-lbl" secondAttribute="bottom" constant="12" id="HlI-v1-5rk"/>
+                            <constraint firstItem="mp2-01-lbl" firstAttribute="top" secondItem="mpv-01-chk" secondAttribute="bottom" constant="10" id="mp2-30-top"/>
+                            <constraint firstItem="mp2-01-lbl" firstAttribute="leading" secondItem="mpv-01-chk" secondAttribute="leading" constant="20" id="mp2-31-lea"/>
+                            <constraint firstItem="mp2-03-pop" firstAttribute="firstBaseline" secondItem="mp2-01-lbl" secondAttribute="firstBaseline" id="mp2-32-bas"/>
+                            <constraint firstItem="mp2-03-pop" firstAttribute="leading" secondItem="mp2-01-lbl" secondAttribute="trailing" constant="8" id="mp2-33-lea"/>
+                            <constraint firstItem="mp2-12-lbl" firstAttribute="top" secondItem="mp2-01-lbl" secondAttribute="bottom" constant="14" id="mp2-34-top"/>
+                            <constraint firstItem="mp2-12-lbl" firstAttribute="trailing" secondItem="mp2-01-lbl" secondAttribute="trailing" id="mp2-35-tra"/>
+                            <constraint firstItem="mp2-14-pop" firstAttribute="firstBaseline" secondItem="mp2-12-lbl" secondAttribute="firstBaseline" id="mp2-36-bas"/>
+                            <constraint firstItem="mp2-14-pop" firstAttribute="leading" secondItem="mp2-01-lbl" secondAttribute="trailing" constant="8" id="mp2-37-lea"/>
+                            <constraint firstItem="mp2-23-lbl" firstAttribute="top" secondItem="mp2-12-lbl" secondAttribute="bottom" constant="14" id="mp2-38-top"/>
+                            <constraint firstItem="mp2-23-lbl" firstAttribute="trailing" secondItem="mp2-01-lbl" secondAttribute="trailing" id="mp2-39-tra"/>
+                            <constraint firstItem="mp2-25-sld" firstAttribute="centerY" secondItem="mp2-23-lbl" secondAttribute="centerY" id="mp2-40-cey"/>
+                            <constraint firstItem="mp2-25-sld" firstAttribute="leading" secondItem="mp2-01-lbl" secondAttribute="trailing" constant="8" id="mp2-41-lea"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mp2-25-sld" secondAttribute="trailing" constant="35" id="mp2-42-tge"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mp2-03-pop" secondAttribute="trailing" constant="35" id="mp2-43-tge"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mp2-14-pop" secondAttribute="trailing" constant="35" id="mp2-44-tge"/>
                             <constraint firstItem="mpv-01-chk" firstAttribute="leading" secondItem="dim-20-chk" secondAttribute="leading" id="mpv-05-lea"/>
                             <constraint firstItem="mpv-01-chk" firstAttribute="top" secondItem="dim-20-chk" secondAttribute="bottom" constant="6" symbolic="YES" id="mpv-04-top"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mpv-01-chk" secondAttribute="trailing" constant="20" symbolic="YES" id="mpv-06-tra"/>
@@ -1544,6 +1631,9 @@ CA
                         <outlet property="titleFontSize" destination="dim-09-pop" id="dim-51-out"/>
                         <outlet property="boldTitles" destination="dim-20-chk" id="dim-52-out"/>
                         <outlet property="miniPreview" destination="mpv-01-chk" id="mpv-07-out"/>
+                        <outlet property="miniPreviewFontSize" destination="mp2-03-pop" id="mp2-50-out"/>
+                        <outlet property="miniPreviewLines" destination="mp2-14-pop" id="mp2-51-out"/>
+                        <outlet property="miniPreviewBrightness" destination="mp2-25-sld" id="mp2-52-out"/>
                     </connections>
                 </viewController>
                 <customObject id="7Tr-yU-uWi" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -3588,7 +3678,7 @@ Olena Hlushcneko</string>
             <objects>
                 <viewController title="Editor" id="ssC-ed-19K" customClass="PreferencesEditorViewController" customModule="FSNotes" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="GY1-6c-5uL">
-                        <rect key="frame" x="0.0" y="0.0" width="468" height="567"/>
+                        <rect key="frame" x="0.0" y="0.0" width="468" height="591"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="B1k-4N-l26">
@@ -3693,6 +3783,21 @@ Olena Hlushcneko</string>
                                 <sliderCell key="cell" state="on" alignment="left" minValue="10" maxValue="200" doubleValue="50" tickMarkPosition="above" numberOfTickMarks="10" sliderType="linear" id="UC2-tH-UtC"/>
                                 <connections>
                                     <action selector="marginSize:" target="ssC-ed-19K" id="Hhx-hm-H5O"/>
+                                </connections>
+                            </slider>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="edb-01-lbl">
+                                <rect key="frame" x="33" y="237" width="91" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Text Brightness:" id="edb-02-lbc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="edb-03-sld">
+                                <rect key="frame" x="147" y="237" width="286" height="16"/>
+                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="0.3" maxValue="1" doubleValue="1" tickMarkPosition="above" numberOfTickMarks="8" sliderType="linear" id="edb-04-slc"/>
+                                <connections>
+                                    <action selector="editorTextBrightness:" target="ssC-ed-19K" id="edb-05-act"/>
                                 </connections>
                             </slider>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DQU-Se-i0R">
@@ -3998,7 +4103,13 @@ Olena Hlushcneko</string>
                             <constraint firstItem="Kcg-vn-Dwj" firstAttribute="trailing" secondItem="mLR-t7-nz0" secondAttribute="trailing" id="t3P-9h-M9O"/>
                             <constraint firstItem="7Az-gx-yGL" firstAttribute="top" secondItem="B07-UG-KXb" secondAttribute="bottom" constant="10" symbolic="YES" id="t7Z-Fy-QdR"/>
                             <constraint firstItem="gk5-il-WSG" firstAttribute="trailing" secondItem="cj1-ab-Sv6" secondAttribute="trailing" id="uDF-5L-1Qp"/>
-                            <constraint firstItem="2ZF-VY-6Ij" firstAttribute="top" secondItem="3el-ze-TIn" secondAttribute="bottom" constant="20" id="uQn-Tx-nFn"/>
+                            <constraint firstItem="2ZF-VY-6Ij" firstAttribute="top" secondItem="edb-01-lbl" secondAttribute="bottom" constant="20" id="uQn-Tx-nFn"/>
+                            <constraint firstItem="edb-01-lbl" firstAttribute="top" secondItem="3el-ze-TIn" secondAttribute="bottom" constant="8" symbolic="YES" id="edb-06-top"/>
+                            <constraint firstItem="edb-01-lbl" firstAttribute="trailing" secondItem="3el-ze-TIn" secondAttribute="trailing" id="edb-07-tra"/>
+                            <constraint firstItem="edb-01-lbl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GY1-6c-5uL" secondAttribute="leading" constant="35" id="edb-08-lea"/>
+                            <constraint firstItem="edb-03-sld" firstAttribute="centerY" secondItem="edb-01-lbl" secondAttribute="centerY" id="edb-09-cey"/>
+                            <constraint firstItem="edb-03-sld" firstAttribute="leading" secondItem="gl0-rI-S66" secondAttribute="leading" id="edb-10-lea"/>
+                            <constraint firstItem="edb-03-sld" firstAttribute="trailing" secondItem="gl0-rI-S66" secondAttribute="trailing" id="edb-11-tra"/>
                             <constraint firstItem="bEN-ep-bl6" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GY1-6c-5uL" secondAttribute="leading" constant="35" id="vH1-tR-yNz"/>
                             <constraint firstItem="9qv-bd-BU8" firstAttribute="centerY" secondItem="dKW-T5-3Vc" secondAttribute="centerY" id="viq-c7-D8b"/>
                             <constraint firstItem="QvM-a9-vnf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GY1-6c-5uL" secondAttribute="leading" constant="35" id="vxD-V3-CzO"/>
@@ -4027,6 +4138,7 @@ Olena Hlushcneko</string>
                         <outlet property="lineSpacing" destination="T2k-ya-69N" id="JH9-pd-ke1"/>
                         <outlet property="lineWidth" destination="DQU-Se-i0R" id="k9W-FU-OtS"/>
                         <outlet property="marginSize" destination="gl0-rI-S66" id="Apd-uE-KF3"/>
+                        <outlet property="editorTextBrightness" destination="edb-03-sld" id="edb-12-out"/>
                         <outlet property="markdownCodeTheme" destination="xZA-pB-1nm" id="lkX-04-F8B"/>
                         <outlet property="noteFontPreview" destination="7Az-gx-yGL" id="Glc-ZA-s8C"/>
                     </connections>

--- a/FSNotes/Preferences/PreferencesEditorViewController.swift
+++ b/FSNotes/Preferences/PreferencesEditorViewController.swift
@@ -21,6 +21,7 @@ class PreferencesEditorViewController: NSViewController {
     @IBOutlet weak var imagesWidth: NSSlider!
     @IBOutlet weak var lineWidth: NSSlider!
     @IBOutlet weak var marginSize: NSSlider!
+    @IBOutlet weak var editorTextBrightness: NSSlider!
     @IBOutlet weak var inlineTags: NSButton!
     @IBOutlet weak var clickableLinks: NSButton!
     
@@ -33,7 +34,7 @@ class PreferencesEditorViewController: NSViewController {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 495)
+        preferredContentSize = NSSize(width: 550, height: 519)
     }
 
     override func viewDidAppear() {
@@ -54,6 +55,8 @@ class PreferencesEditorViewController: NSViewController {
         lineWidth.floatValue = UserDefaultsManagement.lineWidth
 
         marginSize.floatValue = UserDefaultsManagement.marginSize
+
+        editorTextBrightness.doubleValue = UserDefaultsManagement.editorTextBrightness
 
         inlineTags.state = UserDefaultsManagement.inlineTags ? .on : .off
         
@@ -198,6 +201,20 @@ class PreferencesEditorViewController: NSViewController {
                 MPreviewView.template = nil
                 NotesTextProcessor.resetCaches()
     
+                evc.refillEditArea(force: true)
+            }
+        }
+    }
+
+    @IBAction func editorTextBrightness(_ sender: NSSlider) {
+        UserDefaultsManagement.editorTextBrightness = sender.doubleValue
+
+        let editors = AppDelegate.getEditTextViews()
+        for editor in editors {
+            if let evc = editor.editorViewController {
+                MPreviewView.template = nil
+                NotesTextProcessor.resetCaches()
+
                 evc.refillEditArea(force: true)
             }
         }

--- a/FSNotes/Preferences/PreferencesEditorViewController.swift
+++ b/FSNotes/Preferences/PreferencesEditorViewController.swift
@@ -209,6 +209,10 @@ class PreferencesEditorViewController: NSViewController {
     @IBAction func editorTextBrightness(_ sender: NSSlider) {
         UserDefaultsManagement.editorTextBrightness = sender.doubleValue
 
+        // Colors are baked into cached note attributes; drop them so the
+        // open note re-highlights with the new brightness.
+        Storage.shared().resetCacheAttributes()
+
         let editors = AppDelegate.getEditTextViews()
         for editor in editors {
             if let evc = editor.editorViewController {

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -19,10 +19,14 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBOutlet weak var horizontalOrientation: NSButton!
     @IBOutlet weak var showDockIcon: NSButton!
     @IBOutlet weak var showInMenuBar: NSButton!
+    @IBOutlet weak var showNoteCounts: NSButton!
+    @IBOutlet weak var textBrightness: NSSlider!
+    @IBOutlet weak var titleFontSize: NSPopUpButton!
+    @IBOutlet weak var boldTitles: NSButton!
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 460)
+        preferredContentSize = NSSize(width: 550, height: 560)
     }
 
     override func viewDidAppear() {
@@ -44,7 +48,15 @@ class PreferencesUserInterfaceViewController: NSViewController {
         hideDate.state = UserDefaultsManagement.hideDate ? .on : .off
 
         firstLineAsTitle.state = UserDefaultsManagement.firstLineAsTitle ? .on : .off
-        
+
+        showNoteCounts.state = UserDefaultsManagement.showNoteCountsInSidebar ? .on : .off
+
+        textBrightness.doubleValue = UserDefaultsManagement.notesListTextBrightness
+
+        titleFontSize.selectItem(withTag: UserDefaultsManagement.noteTitleFontSize)
+
+        boldTitles.state = UserDefaultsManagement.boldNoteTitles ? .on : .off
+
         horizontalOrientation.state =
             UserDefaultsManagement
             .horizontalOrientation ? .on : .off
@@ -81,6 +93,36 @@ class PreferencesUserInterfaceViewController: NSViewController {
 
     @IBAction func hideDate(_ sender: NSButton) {
         UserDefaultsManagement.hideDate = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func showNoteCounts(_ sender: NSButton) {
+        UserDefaultsManagement.showNoteCountsInSidebar = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+        vc.sidebarOutlineView.reloadData()
+    }
+
+    @IBAction func changeTextBrightness(_ sender: NSSlider) {
+        UserDefaultsManagement.notesListTextBrightness = sender.doubleValue
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func changeTitleFontSize(_ sender: NSPopUpButton) {
+        guard let tag = sender.selectedItem?.tag else { return }
+
+        UserDefaultsManagement.noteTitleFontSize = tag
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func boldTitles(_ sender: NSButton) {
+        UserDefaultsManagement.boldNoteTitles = (sender.state == .on)
 
         guard let vc = ViewController.shared() else { return }
         vc.notesTableView.reloadData()

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -23,10 +23,11 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBOutlet weak var textBrightness: NSSlider!
     @IBOutlet weak var titleFontSize: NSPopUpButton!
     @IBOutlet weak var boldTitles: NSButton!
+    @IBOutlet weak var miniPreview: NSButton!
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 560)
+        preferredContentSize = NSSize(width: 550, height: 582)
     }
 
     override func viewDidAppear() {
@@ -56,6 +57,8 @@ class PreferencesUserInterfaceViewController: NSViewController {
         titleFontSize.selectItem(withTag: UserDefaultsManagement.noteTitleFontSize)
 
         boldTitles.state = UserDefaultsManagement.boldNoteTitles ? .on : .off
+
+        miniPreview.state = UserDefaultsManagement.miniPreview ? .on : .off
 
         horizontalOrientation.state =
             UserDefaultsManagement
@@ -125,6 +128,16 @@ class PreferencesUserInterfaceViewController: NSViewController {
         UserDefaultsManagement.boldNoteTitles = (sender.state == .on)
 
         guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func miniPreview(_ sender: NSButton) {
+        UserDefaultsManagement.miniPreview = (sender.state == .on)
+
+        guard let vc = ViewController.shared() else { return }
+
+        // Full reload re-queries heightOfRow for every row, so the
+        // card/list switch applies live.
         vc.notesTableView.reloadData()
     }
 

--- a/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
+++ b/FSNotes/Preferences/PreferencesUserInterfaceViewController.swift
@@ -24,10 +24,13 @@ class PreferencesUserInterfaceViewController: NSViewController {
     @IBOutlet weak var titleFontSize: NSPopUpButton!
     @IBOutlet weak var boldTitles: NSButton!
     @IBOutlet weak var miniPreview: NSButton!
+    @IBOutlet weak var miniPreviewFontSize: NSPopUpButton!
+    @IBOutlet weak var miniPreviewLines: NSPopUpButton!
+    @IBOutlet weak var miniPreviewBrightness: NSSlider!
 
     override func viewWillAppear() {
         super.viewWillAppear()
-        preferredContentSize = NSSize(width: 550, height: 582)
+        preferredContentSize = NSSize(width: 550, height: 666)
     }
 
     override func viewDidAppear() {
@@ -59,6 +62,12 @@ class PreferencesUserInterfaceViewController: NSViewController {
         boldTitles.state = UserDefaultsManagement.boldNoteTitles ? .on : .off
 
         miniPreview.state = UserDefaultsManagement.miniPreview ? .on : .off
+
+        miniPreviewFontSize.selectItem(withTag: UserDefaultsManagement.miniPreviewFontSize)
+
+        miniPreviewLines.selectItem(withTag: UserDefaultsManagement.miniPreviewLines)
+
+        miniPreviewBrightness.doubleValue = UserDefaultsManagement.miniPreviewTextBrightness
 
         horizontalOrientation.state =
             UserDefaultsManagement
@@ -138,6 +147,31 @@ class PreferencesUserInterfaceViewController: NSViewController {
 
         // Full reload re-queries heightOfRow for every row, so the
         // card/list switch applies live.
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func changeMiniPreviewFontSize(_ sender: NSPopUpButton) {
+        guard let tag = sender.selectedItem?.tag else { return }
+
+        UserDefaultsManagement.miniPreviewFontSize = tag
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func changeMiniPreviewLines(_ sender: NSPopUpButton) {
+        guard let tag = sender.selectedItem?.tag else { return }
+
+        UserDefaultsManagement.miniPreviewLines = tag
+
+        guard let vc = ViewController.shared() else { return }
+        vc.notesTableView.reloadData()
+    }
+
+    @IBAction func changeMiniPreviewBrightness(_ sender: NSSlider) {
+        UserDefaultsManagement.miniPreviewTextBrightness = sender.doubleValue
+
+        guard let vc = ViewController.shared() else { return }
         vc.notesTableView.reloadData()
     }
 

--- a/FSNotes/View/MiniPreviewCellView.swift
+++ b/FSNotes/View/MiniPreviewCellView.swift
@@ -184,6 +184,8 @@ class MiniPreviewCellView: NoteCellView {
         preview.stringValue = getCardPreviewText(note: note)
 
         applyCardStyle()
+        renderPin()
+        updateCardAppearance()
     }
 
     // Called by NotesTableView.performReload; card text has its own fixed style.
@@ -191,24 +193,22 @@ class MiniPreviewCellView: NoteCellView {
         applyCardStyle()
     }
 
-    // Intentionally no super call: NoteCellView.draw() touches storyboard-only
-    // outlets (titleConstraint) and re-applies list styling that does not
-    // exist in the card layout.
-    override func draw(_ dirtyRect: NSRect) {
-        applyCardStyle()
-        renderPin()
-        updateCardAppearance()
-    }
+    // Intentionally empty, no super call: NoteCellView.draw() touches
+    // storyboard-only outlets (titleConstraint) and mutates fonts and
+    // constraints, which is not safe during the drawing pass (it corrupts
+    // the Auto Layout engine). All card styling happens in attachHeaders
+    // and the observers below; subviews and the card layer draw themselves.
+    override func draw(_ dirtyRect: NSRect) {}
 
     override var backgroundStyle: NSView.BackgroundStyle {
         didSet {
-            needsDisplay = true
+            updateCardAppearance()
         }
     }
 
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        needsDisplay = true
+        updateCardAppearance()
     }
 
     private func getCardPreviewText(note: Note) -> String {

--- a/FSNotes/View/MiniPreviewCellView.swift
+++ b/FSNotes/View/MiniPreviewCellView.swift
@@ -18,12 +18,19 @@ class MiniPreviewCellView: NoteCellView {
 
     private let cardView = NSView()
 
+    // Cells are reused across reloads; refreshed when preview prefs change.
+    private var cardHeightConstraint: NSLayoutConstraint?
+
     // Strong backing for the weak inherited image outlets; never displayed.
     private var offscreenImageViews = [NSImageView]()
 
-    private static let previewFontSize: CGFloat = 10
+    private static var previewFontSize: CGFloat {
+        return CGFloat(UserDefaultsManagement.miniPreviewFontSize)
+    }
     private static let previewLineSpacing: CGFloat = 2
-    private static let previewLines = 8
+    private static var previewLines: Int {
+        return UserDefaultsManagement.miniPreviewLines
+    }
     private static let previewMaxChars = 1500
     private static let cardPadding: CGFloat = 10
     private static let cardCornerRadius: CGFloat = 8
@@ -123,11 +130,14 @@ class MiniPreviewCellView: NoteCellView {
         let sideMargin = MiniPreviewCellView.sideMargin
         let cardPadding = MiniPreviewCellView.cardPadding
 
+        let cardHeight = cardView.heightAnchor.constraint(equalToConstant: MiniPreviewCellView.cardHeight)
+        cardHeightConstraint = cardHeight
+
         NSLayoutConstraint.activate([
             cardView.topAnchor.constraint(equalTo: topAnchor, constant: MiniPreviewCellView.cardTopMargin),
             cardView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideMargin),
             cardView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -sideMargin),
-            cardView.heightAnchor.constraint(equalToConstant: MiniPreviewCellView.cardHeight),
+            cardHeight,
 
             previewField.topAnchor.constraint(equalTo: cardView.topAnchor, constant: cardPadding),
             previewField.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: cardPadding),
@@ -223,15 +233,21 @@ class MiniPreviewCellView: NoteCellView {
         paragraph.lineSpacing = MiniPreviewCellView.previewLineSpacing
         paragraph.lineBreakMode = .byTruncatingTail
 
+        let previewBrightness = UserDefaultsManagement.miniPreviewTextBrightness
+        let previewColor = previewBrightness < 1.0
+            ? NSColor.labelColor.withAlphaComponent(CGFloat(previewBrightness))
+            : NSColor.labelColor
+
         preview.attributedStringValue = NSAttributedString(
             string: preview.stringValue,
             attributes: [
                 .font: previewFont,
                 .paragraphStyle: paragraph,
-                .foregroundColor: NSColor.labelColor
+                .foregroundColor: previewColor
             ]
         )
         preview.maximumNumberOfLines = MiniPreviewCellView.previewLines
+        cardHeightConstraint?.constant = MiniPreviewCellView.cardHeight
 
         let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
         name.font = UserDefaultsManagement.boldNoteTitles

--- a/FSNotes/View/MiniPreviewCellView.swift
+++ b/FSNotes/View/MiniPreviewCellView.swift
@@ -1,0 +1,267 @@
+//
+//  MiniPreviewCellView.swift
+//  FSNotes
+//
+//  Apple Notes-style "card" cell for the notes list (MiniPreview mode).
+//
+//  Fully programmatic subclass of NoteCellView: it creates its own subviews
+//  and assigns them to the inherited outlets (name, preview, date, pin), so
+//  shared call sites (performReload, reloadDate, renderPin) keep working.
+//  The weak image outlets are backed by retained offscreen dummies so shared
+//  code paths never hit nil. NoteCellView.draw() is overridden without a
+//  super call because storyboard-only outlets (titleConstraint) are nil here.
+//
+
+import Cocoa
+
+class MiniPreviewCellView: NoteCellView {
+
+    private let cardView = NSView()
+
+    // Strong backing for the weak inherited image outlets; never displayed.
+    private var offscreenImageViews = [NSImageView]()
+
+    private static let previewFontSize: CGFloat = 10
+    private static let previewLineSpacing: CGFloat = 2
+    private static let previewLines = 8
+    private static let previewMaxChars = 1500
+    private static let cardPadding: CGFloat = 10
+    private static let cardCornerRadius: CGFloat = 8
+    private static let sideMargin: CGFloat = 12
+    private static let cardTopMargin: CGFloat = 6
+    private static let titleSpacing: CGFloat = 8
+    private static let dateSpacing: CGFloat = 2
+    private static let bottomMargin: CGFloat = 10
+    private static let dateFontSize: CGFloat = 11
+
+    public static var cardHeight: CGFloat {
+        let font = NSFont.systemFont(ofSize: previewFontSize)
+        let textHeight = CGFloat(previewLines) * font.lineHeightCustom
+            + CGFloat(previewLines - 1) * previewLineSpacing
+
+        return ceil(textHeight) + cardPadding * 2
+    }
+
+    public static var rowHeight: CGFloat {
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        let titleFont = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        var height = cardTopMargin
+            + cardHeight
+            + titleSpacing
+            + ceil(titleFont.lineHeightCustom)
+
+        if !UserDefaultsManagement.hideDate {
+            let dateFont = NSFont.systemFont(ofSize: dateFontSize)
+            height += dateSpacing + ceil(dateFont.lineHeightCustom)
+        }
+
+        return height + bottomMargin
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupSubviews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupSubviews()
+    }
+
+    private func setupSubviews() {
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        cardView.wantsLayer = true
+        cardView.layer?.cornerRadius = MiniPreviewCellView.cardCornerRadius
+        cardView.layer?.masksToBounds = true
+        addSubview(cardView)
+
+        let previewField = PreviewTextField(frame: .zero)
+        configureLabel(previewField)
+        previewField.alignment = .natural
+        previewField.lineBreakMode = .byWordWrapping
+        previewField.cell?.wraps = true
+        previewField.cell?.truncatesLastVisibleLine = true
+        previewField.maximumNumberOfLines = MiniPreviewCellView.previewLines
+        previewField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        previewField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        previewField.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        cardView.addSubview(previewField)
+        preview = previewField
+
+        let titleField = NSTextField(frame: .zero)
+        configureLabel(titleField)
+        titleField.alignment = .center
+        titleField.lineBreakMode = .byTruncatingTail
+        titleField.maximumNumberOfLines = 1
+        addSubview(titleField)
+        name = titleField
+
+        let dateField = NSTextField(frame: .zero)
+        configureLabel(dateField)
+        dateField.alignment = .center
+        dateField.lineBreakMode = .byClipping
+        dateField.maximumNumberOfLines = 1
+        addSubview(dateField)
+        date = dateField
+
+        let pinView = NSImageView(frame: .zero)
+        pinView.translatesAutoresizingMaskIntoConstraints = false
+        pinView.imageScaling = .scaleProportionallyDown
+        pinView.isHidden = true
+        addSubview(pinView)
+        pin = pinView
+
+        let dummies = [NSImageView(), NSImageView(), NSImageView()]
+        offscreenImageViews = dummies
+        imagePreview = dummies[0]
+        imagePreviewSecond = dummies[1]
+        imagePreviewThird = dummies[2]
+
+        let sideMargin = MiniPreviewCellView.sideMargin
+        let cardPadding = MiniPreviewCellView.cardPadding
+
+        NSLayoutConstraint.activate([
+            cardView.topAnchor.constraint(equalTo: topAnchor, constant: MiniPreviewCellView.cardTopMargin),
+            cardView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: sideMargin),
+            cardView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -sideMargin),
+            cardView.heightAnchor.constraint(equalToConstant: MiniPreviewCellView.cardHeight),
+
+            previewField.topAnchor.constraint(equalTo: cardView.topAnchor, constant: cardPadding),
+            previewField.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: cardPadding),
+            previewField.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -cardPadding),
+            previewField.bottomAnchor.constraint(lessThanOrEqualTo: cardView.bottomAnchor, constant: -cardPadding),
+
+            titleField.topAnchor.constraint(equalTo: cardView.bottomAnchor, constant: MiniPreviewCellView.titleSpacing),
+            titleField.centerXAnchor.constraint(equalTo: centerXAnchor),
+            titleField.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: sideMargin + 22),
+            titleField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -(sideMargin + 22)),
+
+            dateField.topAnchor.constraint(equalTo: titleField.bottomAnchor, constant: MiniPreviewCellView.dateSpacing),
+            dateField.centerXAnchor.constraint(equalTo: centerXAnchor),
+            dateField.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: sideMargin),
+            dateField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -sideMargin),
+
+            pinView.trailingAnchor.constraint(equalTo: titleField.leadingAnchor, constant: -4),
+            pinView.centerYAnchor.constraint(equalTo: titleField.centerYAnchor),
+            pinView.widthAnchor.constraint(equalToConstant: 14),
+            pinView.heightAnchor.constraint(equalToConstant: 14)
+        ])
+    }
+
+    private func configureLabel(_ field: NSTextField) {
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.isEditable = false
+        field.isSelectable = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.cell?.isScrollable = false
+    }
+
+    override func configure(note: Note) {
+        super.configure(note: note)
+
+        // renderPin() reads objectValue
+        objectValue = note
+    }
+
+    override func attachHeaders(note: Note) {
+        name.stringValue = note.getTitle() ?? ""
+        date.stringValue = note.getDateForLabel()
+        preview.stringValue = getCardPreviewText(note: note)
+
+        applyCardStyle()
+    }
+
+    // Called by NotesTableView.performReload; card text has its own fixed style.
+    override func applyPreviewStyle() {
+        applyCardStyle()
+    }
+
+    // Intentionally no super call: NoteCellView.draw() touches storyboard-only
+    // outlets (titleConstraint) and re-applies list styling that does not
+    // exist in the card layout.
+    override func draw(_ dirtyRect: NSRect) {
+        applyCardStyle()
+        renderPin()
+        updateCardAppearance()
+    }
+
+    override var backgroundStyle: NSView.BackgroundStyle {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
+    private func getCardPreviewText(note: Note) -> String {
+        var text = String(note.content.string.prefix(MiniPreviewCellView.previewMaxChars))
+
+        // The first line is already shown as the note title below the card
+        if note.getTitle() != nil, UserDefaultsManagement.firstLineAsTitle,
+            let newline = text.firstIndex(of: "\n") {
+            text = String(text[text.index(after: newline)...])
+        }
+
+        return text
+            .stripMarkdownSyntax()
+            .replacingOccurrences(of: "\n{3,}", with: "\n\n", options: .regularExpression)
+            .replacingOccurrences(of: "[ \\t]{2,}", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func applyCardStyle() {
+        let previewFont = NSFont.systemFont(ofSize: MiniPreviewCellView.previewFontSize)
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = MiniPreviewCellView.previewLineSpacing
+        paragraph.lineBreakMode = .byTruncatingTail
+
+        preview.attributedStringValue = NSAttributedString(
+            string: preview.stringValue,
+            attributes: [
+                .font: previewFont,
+                .paragraphStyle: paragraph,
+                .foregroundColor: NSColor.labelColor
+            ]
+        )
+        preview.maximumNumberOfLines = MiniPreviewCellView.previewLines
+
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        name.font = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        let brightness = UserDefaultsManagement.notesListTextBrightness
+        if brightness < 1.0 {
+            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
+        } else {
+            name.textColor = .labelColor
+        }
+
+        date.font = NSFont.systemFont(ofSize: MiniPreviewCellView.dateFontSize)
+        date.textColor = .secondaryLabelColor
+        date.isHidden = UserDefaultsManagement.hideDate
+    }
+
+    private func updateCardAppearance() {
+        guard let layer = cardView.layer else { return }
+
+        layer.backgroundColor = NSColor.textColor.withAlphaComponent(0.04).cgColor
+
+        let isRowSelected = (superview as? NSTableRowView)?.isSelected == true
+        if isRowSelected {
+            layer.borderColor = NSColor.controlAccentColor.cgColor
+            layer.borderWidth = 2
+        } else {
+            layer.borderColor = NSColor.separatorColor.cgColor
+            layer.borderWidth = 1
+        }
+    }
+}

--- a/FSNotes/View/MiniPreviewCellView.swift
+++ b/FSNotes/View/MiniPreviewCellView.swift
@@ -211,7 +211,26 @@ class MiniPreviewCellView: NoteCellView {
         updateCardAppearance()
     }
 
+    // Stripped card text per note version: content is read once per edit
+    // instead of on every cell render (it can be mutated by background
+    // indexing, so fewer reads also mean fewer chances to race with it).
+    private static let cardTextCache = NSCache<NSString, NSString>()
+
     private func getCardPreviewText(note: Note) -> String {
+        let modified = note.modifiedLocalAt.timeIntervalSince1970
+        let key = "\(note.url.path)|\(modified)|\(UserDefaultsManagement.firstLineAsTitle)" as NSString
+
+        if let cached = MiniPreviewCellView.cardTextCache.object(forKey: key) {
+            return cached as String
+        }
+
+        let text = buildCardPreviewText(note: note)
+        MiniPreviewCellView.cardTextCache.setObject(text as NSString, forKey: key)
+
+        return text
+    }
+
+    private func buildCardPreviewText(note: Note) -> String {
         var text = String(note.content.string.prefix(MiniPreviewCellView.previewMaxChars))
 
         // The first line is already shown as the note title below the card

--- a/FSNotes/View/NameTextField.swift
+++ b/FSNotes/View/NameTextField.swift
@@ -12,7 +12,8 @@ class NameTextField: NSTextField {
     override func becomeFirstResponder() -> Bool {
         let status = super.becomeFirstResponder()
 
-        self.textColor = NSColor.init(named: "mainText")
+        self.textColor = NSColor.init(named: "mainText")?
+            .withAlphaComponent(CGFloat(UserDefaultsManagement.notesListTextBrightness))
 
         return status
     }

--- a/FSNotes/View/NoteCellView.swift
+++ b/FSNotes/View/NoteCellView.swift
@@ -70,6 +70,18 @@ class NoteCellView: NSTableCellView {
         renderPin()
         name.layer?.zPosition = 1000
 
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        name.font = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        let brightness = UserDefaultsManagement.notesListTextBrightness
+        if brightness < 1.0 {
+            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
+        } else {
+            name.textColor = .labelColor
+        }
+
         if let descriptor = date.font?.fontDescriptor {
             date.font = NSFont.init(descriptor: descriptor, size: 11)
         }

--- a/FSNotes/View/NoteCellView.swift
+++ b/FSNotes/View/NoteCellView.swift
@@ -70,18 +70,6 @@ class NoteCellView: NSTableCellView {
         renderPin()
         name.layer?.zPosition = 1000
 
-        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
-        name.font = UserDefaultsManagement.boldNoteTitles
-            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
-            : NSFont.systemFont(ofSize: titleSize)
-
-        let brightness = UserDefaultsManagement.notesListTextBrightness
-        if brightness < 1.0 {
-            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
-        } else {
-            name.textColor = .labelColor
-        }
-
         if let descriptor = date.font?.fontDescriptor {
             date.font = NSFont.init(descriptor: descriptor, size: 11)
         }
@@ -393,5 +381,23 @@ class NoteCellView: NSTableCellView {
         }
 
         self.date.stringValue = note.getDateForLabel()
+
+        applyTitleStyle()
+    }
+
+    // Kept out of draw(): font changes invalidate intrinsic content size,
+    // and layout must not be mutated during the drawing pass.
+    public func applyTitleStyle() {
+        let titleSize = CGFloat(UserDefaultsManagement.noteTitleFontSize)
+        name.font = UserDefaultsManagement.boldNoteTitles
+            ? NSFont.systemFont(ofSize: titleSize, weight: .semibold)
+            : NSFont.systemFont(ofSize: titleSize)
+
+        let brightness = UserDefaultsManagement.notesListTextBrightness
+        if brightness < 1.0 {
+            name.textColor = NSColor(named: "mainText")?.withAlphaComponent(CGFloat(brightness))
+        } else {
+            name.textColor = .labelColor
+        }
     }
 }

--- a/FSNotes/View/NoteRowView.swift
+++ b/FSNotes/View/NoteRowView.swift
@@ -9,11 +9,28 @@
 import Cocoa
 
 class NoteRowView: NSTableRowView {
+    private var isMiniPreview: Bool {
+        return UserDefaultsManagement.miniPreview && !UserDefaultsManagement.horizontalOrientation
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
     }
-    
+
+    // MiniPreview shows selection as an accent border on the card, like
+    // Apple Notes; the full-row highlight and separators are skipped.
+    override func drawSelection(in dirtyRect: NSRect) {
+        if isMiniPreview {
+            return
+        }
+
+        super.drawSelection(in: dirtyRect)
+    }
+
     override func drawSeparator(in dirtyRect: NSRect) {
+        if isMiniPreview {
+            return
+        }
         let leftInset: CGFloat = 23
         let rightInset: CGFloat = 15
         let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0

--- a/FSNotes/View/NotesTableView.swift
+++ b/FSNotes/View/NotesTableView.swift
@@ -208,6 +208,10 @@ class NotesTableView: NSTableView,
             note.loadPreviewInfo()
         }
 
+        if UserDefaultsManagement.miniPreview && !UserDefaultsManagement.horizontalOrientation {
+            return MiniPreviewCellView.rowHeight
+        }
+
         if !UserDefaultsManagement.horizontalOrientation
             && !UserDefaultsManagement.hidePreviewImages,
             let urls = note.imageUrl,
@@ -410,6 +414,25 @@ class NotesTableView: NSTableView,
     }
     
     func makeCell(note: Note) -> NoteCellView {
+        if UserDefaultsManagement.miniPreview && !UserDefaultsManagement.horizontalOrientation {
+            let identifier = NSUserInterfaceItemIdentifier(rawValue: "MiniPreviewCellView")
+            let cell: MiniPreviewCellView
+
+            if let reused = makeView(withIdentifier: identifier, owner: self) as? MiniPreviewCellView {
+                cell = reused
+            } else {
+                cell = MiniPreviewCellView(frame: .zero)
+                cell.identifier = identifier
+            }
+
+            cell.imageKeys = []
+            cell.timestamp = nil
+            cell.configure(note: note)
+            cell.attachHeaders(note: note)
+
+            return cell
+        }
+
         let cell = makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "NoteCellView"), owner: self) as! NoteCellView
 
         cell.imageKeys = []
@@ -654,7 +677,12 @@ class NotesTableView: NSTableView,
         
         if let cell = self.view(atColumn: 0, row: i, makeIfNecessary: false) as? NoteCellView {
             cell.date.stringValue = note.getDateForLabel()
-            cell.loadImagesPreview(position: i, urls: urls)
+
+            // MiniPreview cards render no image previews
+            if !(cell is MiniPreviewCellView) {
+                cell.loadImagesPreview(position: i, urls: urls)
+            }
+
             cell.attachHeaders(note: note)
             cell.renderPin()
             cell.applyPreviewStyle()

--- a/FSNotes/View/SidebarCellView.swift
+++ b/FSNotes/View/SidebarCellView.swift
@@ -15,6 +15,52 @@ class SidebarCellView: NSTableCellView {
     public var type: SidebarItemType?
     public var storage = Storage.shared()
 
+    private var countLabel: NSTextField?
+
+    public func updateCount(_ count: Int?) {
+        guard let count = count, UserDefaultsManagement.showNoteCountsInSidebar else {
+            // Do not create the label (and its constraints) for cells that
+            // never showed a count — just reset reused ones.
+            countLabel?.stringValue = ""
+            countLabel?.isHidden = true
+            return
+        }
+
+        let field = countLabel ?? createCountLabel()
+        field.stringValue = String(count)
+        field.isHidden = false
+    }
+
+    private func createCountLabel() -> NSTextField {
+        let field = NSTextField()
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.isEditable = false
+        field.isSelectable = false
+        field.isBordered = false
+        field.drawsBackground = false
+        field.backgroundColor = .clear
+        field.alignment = .right
+        field.font = NSFont.systemFont(ofSize: 11)
+        field.textColor = .secondaryLabelColor
+        field.lineBreakMode = .byClipping
+
+        field.setContentHuggingPriority(.required, for: .horizontal)
+        field.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        addSubview(field)
+
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        NSLayoutConstraint.activate([
+            field.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            field.centerYAnchor.constraint(equalTo: label.centerYAnchor),
+            field.leadingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor, constant: 4)
+        ])
+
+        countLabel = field
+        return field
+    }
+
     @IBAction func projectName(_ sender: NSTextField) {
         let cell = sender.superview as? SidebarCellView
 

--- a/FSNotes/View/SidebarOutlineView.swift
+++ b/FSNotes/View/SidebarOutlineView.swift
@@ -457,6 +457,9 @@ class SidebarOutlineView: NSOutlineView,
 
         cell.icon.contentTintColor = NSColor.controlAccentColor
 
+        // Reset possible stale count from a reused cell; project rows set it below.
+        cell.updateCount(nil)
+
         if let tag = item as? FSTag {
             cell.type = .Tag
 
@@ -498,6 +501,8 @@ class SidebarOutlineView: NSOutlineView,
             cell.icon.isHidden = false
             cell.label.frame.origin.x = 25
             cell.textField?.stringValue = project.label
+
+            cell.updateCount(UserDefaultsManagement.showNoteCountsInSidebar ? project.getNotes().count : nil)
 
         } else if let si = item as? SidebarItem {
             let name = si.type == .Separator ? "" : si.name

--- a/FSNotesCore/Extensions/String+.swift
+++ b/FSNotesCore/Extensions/String+.swift
@@ -58,6 +58,44 @@ public extension String {
             .replacingOccurrences(of: "\u{FFFC}", with: "")
     }
 
+    /// Strips common markdown syntax for plain-text display (MiniPreview cards).
+    /// Builds on trimMDSyntax(), additionally handling emphasis markers,
+    /// links, blockquotes, list markers and common HTML entities.
+    func stripMarkdownSyntax() -> String {
+        var result = trimMDSyntax()
+
+        let regexReplacements: [(String, String)] = [
+            ("!\\[([^\\]]*)\\]\\(([^)]*)\\)", "$1"),                 // images -> alt text
+            ("\\[([^\\]]+)\\]\\(([^)]*)\\)", "$1"),                  // links -> link text
+            ("(?m)^\\s{0,3}#{1,6}[ \\t]+", ""),                      // heading markers
+            ("(?m)^\\s{0,3}>[ \\t]?", ""),                           // blockquotes
+            ("(\\*{1,3}|_{1,3}|~~)(?=\\S)(.+?)(?<=\\S)\\1", "$2"),   // bold/italic/strike
+            ("`([^`\\n]+)`", "$1"),                                  // inline code
+            ("(?m)^[ \\t]*([-*_][ \\t]*){3,}$", ""),                 // horizontal rules
+            ("(?m)^\\s*[-+*][ \\t]+", "• "),                        // unordered lists -> bullet
+            ("[*_]{2,}|~~", "")                                      // leftover markers
+        ]
+
+        for (pattern, template) in regexReplacements {
+            result = result.replacingOccurrences(
+                of: pattern,
+                with: template,
+                options: .regularExpression
+            )
+        }
+
+        let entities: [(String, String)] = [
+            ("&quot;", "\""), ("&#34;", "\""), ("&apos;", "'"), ("&#39;", "'"),
+            ("&lt;", "<"), ("&gt;", ">"), ("&nbsp;", " "), ("&amp;", "&")
+        ]
+
+        for (entity, character) in entities {
+            result = result.replacingOccurrences(of: entity, with: character)
+        }
+
+        return result
+    }
+
     func getPrefixMatchSequentially(char: String) -> String? {
         var result = String()
 

--- a/FSNotesCore/NotesTextProcessor.swift
+++ b/FSNotesCore/NotesTextProcessor.swift
@@ -21,6 +21,11 @@ public class NotesTextProcessor {
 
     public static var fontColor: NSColor {
         get {
+            let brightness = UserDefaultsManagement.editorTextBrightness
+            if brightness < 1.0 {
+                return NSColor(named: "mainText")!.withAlphaComponent(CGFloat(brightness))
+            }
+
             return NSColor(named: "mainText")!
         }
     }

--- a/FSNotesCore/UserDefaultsManagement.swift
+++ b/FSNotesCore/UserDefaultsManagement.swift
@@ -118,6 +118,7 @@ public class UserDefaultsManagement {
         static let MarginSizeKey = "marginSize"
         static let MasterPasswordHint = "masterPasswordHint"
         static let MathJaxPreview = "mathJaxPreview"
+        static let MiniPreview = "miniPreview"
         static let NonContiguousLayout = "allowsNonContiguousLayout"
         static let NoteContainer = "noteContainer"
         static let NotesListTextBrightness = "notesListTextBrightness"
@@ -1080,6 +1081,18 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.NotesListTextBrightness)
+        }
+    }
+
+    static var miniPreview: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.MiniPreview) as? Bool {
+                return result
+            }
+            return false
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.MiniPreview)
         }
     }
 

--- a/FSNotesCore/UserDefaultsManagement.swift
+++ b/FSNotesCore/UserDefaultsManagement.swift
@@ -75,6 +75,7 @@ public class UserDefaultsManagement {
         static let CustomWebServer = "customWebServer"
         static let DefaultLanguageKey = "defaultLanguage"
         static let DefaultKeyboardKey = "defaultKeyboard"
+        static let EditorTextBrightness = "editorTextBrightness"
         static let FontNameKey = "font"
         static let FontSizeKey = "fontsize"
         static let FontColorKey = "fontColorKeyed"
@@ -119,6 +120,9 @@ public class UserDefaultsManagement {
         static let MasterPasswordHint = "masterPasswordHint"
         static let MathJaxPreview = "mathJaxPreview"
         static let MiniPreview = "miniPreview"
+        static let MiniPreviewFontSize = "miniPreviewFontSize"
+        static let MiniPreviewLines = "miniPreviewLines"
+        static let MiniPreviewTextBrightness = "miniPreviewTextBrightness"
         static let NonContiguousLayout = "allowsNonContiguousLayout"
         static let NoteContainer = "noteContainer"
         static let NotesListTextBrightness = "notesListTextBrightness"
@@ -1072,6 +1076,18 @@ public class UserDefaultsManagement {
         }
     }
 
+    static var editorTextBrightness: Double {
+        get {
+            if let result = shared?.object(forKey: Constants.EditorTextBrightness) as? Double {
+                return result
+            }
+            return 1.0
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.EditorTextBrightness)
+        }
+    }
+
     static var notesListTextBrightness: Double {
         get {
             if let result = shared?.object(forKey: Constants.NotesListTextBrightness) as? Double {
@@ -1093,6 +1109,42 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.MiniPreview)
+        }
+    }
+
+    static var miniPreviewFontSize: Int {
+        get {
+            if let result = shared?.object(forKey: Constants.MiniPreviewFontSize) as? NSNumber {
+                return result.intValue
+            }
+            return 10
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.MiniPreviewFontSize)
+        }
+    }
+
+    static var miniPreviewLines: Int {
+        get {
+            if let result = shared?.object(forKey: Constants.MiniPreviewLines) as? NSNumber {
+                return result.intValue
+            }
+            return 8
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.MiniPreviewLines)
+        }
+    }
+
+    static var miniPreviewTextBrightness: Double {
+        get {
+            if let result = shared?.object(forKey: Constants.MiniPreviewTextBrightness) as? Double {
+                return result
+            }
+            return 1.0
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.MiniPreviewTextBrightness)
         }
     }
 

--- a/FSNotesCore/UserDefaultsManagement.swift
+++ b/FSNotesCore/UserDefaultsManagement.swift
@@ -60,6 +60,7 @@ public class UserDefaultsManagement {
         static let BackupManually = "backupManually"
         static let BgColorKey = "bgColorKeyed"
         static let boldKey = "boldKeyed"
+        static let BoldNoteTitles = "boldNoteTitles"
         static let CacheDiff = "cacheDiff"
         static let CellSpacing = "cellSpacing"
         static let CellFrameOriginY = "cellFrameOriginY"
@@ -119,6 +120,8 @@ public class UserDefaultsManagement {
         static let MathJaxPreview = "mathJaxPreview"
         static let NonContiguousLayout = "allowsNonContiguousLayout"
         static let NoteContainer = "noteContainer"
+        static let NotesListTextBrightness = "notesListTextBrightness"
+        static let NoteTitleFontSize = "noteTitleFontSize"
         static let Preview = "preview"
         static let PreviewFontSize = "previewFontSize"
         static let ProjectsKey = "projects"
@@ -142,6 +145,7 @@ public class UserDefaultsManagement {
         static let ShowDockIcon = "showDockIcon"
         static let shouldFocusSearchOnESCKeyDown = "shouldFocusSearchOnESCKeyDown"
         static let ShowInMenuBar = "showInMenuBar"
+        static let ShowNoteCountsInSidebar = "showNoteCountsInSidebar"
         static let SmartInsertDelete = "smartInsertDelete"
         static let SnapshotsInterval = "snapshotsInterval"
         static let SnapshotsIntervalMinutes = "snapshotsIntervalMinutes"
@@ -623,7 +627,19 @@ public class UserDefaultsManagement {
             shared?.set(newValue, forKey: Constants.ShowDockIcon)
         }
     }
-    
+
+    static var showNoteCountsInSidebar: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.ShowNoteCountsInSidebar) as? Bool {
+                return result
+            }
+            return true
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.ShowNoteCountsInSidebar)
+        }
+    }
+
     static var editorLineSpacing: Float {
         get {
             if let result = shared?.object(forKey: Constants.LineSpacingEditorKey) as? Float {
@@ -1028,6 +1044,42 @@ public class UserDefaultsManagement {
         }
         set {
             shared?.set(newValue, forKey: Constants.FirstLineAsTitle)
+        }
+    }
+
+    static var boldNoteTitles: Bool {
+        get {
+            if let result = shared?.object(forKey: Constants.BoldNoteTitles) as? Bool {
+                return result
+            }
+            return false
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.BoldNoteTitles)
+        }
+    }
+
+    static var noteTitleFontSize: Int {
+        get {
+            if let result = shared?.object(forKey: Constants.NoteTitleFontSize) as? NSNumber {
+                return result.intValue
+            }
+            return 13
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.NoteTitleFontSize)
+        }
+    }
+
+    static var notesListTextBrightness: Double {
+        get {
+            if let result = shared?.object(forKey: Constants.NotesListTextBrightness) as? Double {
+                return result
+            }
+            return 1.0
+        }
+        set {
+            shared?.set(newValue, forKey: Constants.NotesListTextBrightness)
         }
     }
 


### PR DESCRIPTION
## What

Quality-of-life additions for the macOS app. Everything is opt-in or adjustable via Preferences, and all defaults preserve the current appearance exactly.

### 1. Note counts in the sidebar (Apple Notes style)
Each folder row shows its note count right-aligned in a dim secondary color. The count label is created lazily in `SidebarCellView` (programmatic, 11pt, `.secondaryLabelColor`), so tag/system rows never allocate it and reused cells reset stale counts. **Layout → Show note counts in sidebar** (default on).

### 2. Note list appearance preferences (Layout pane)
- **Note Title Brightness** slider (0.3–1.0) — alpha on the `mainText` color, works in light and dark appearance; 1.0 keeps today's look
- **Bold note titles** checkbox (`.semibold`, default off)
- **Title Font Size** popup (11–16pt, default 13)

### 3. MiniPreview — Apple Notes-style card view for the note list
**Layout → MiniPreview note list** (default off). Each note renders as a rounded card with a markdown-stripped content preview (emphasis/heading/link/code/blockquote markers removed, HTML entities decoded), centered title and dim date below, and an accent border for selection — no full-row highlight, like Apple Notes gallery. Tunable: **preview font size** (9–14pt), **preview lines** (4–12, drives card height) and **preview brightness**. Implemented as a fully programmatic `MiniPreviewCellView` compatible with the existing `NoteCellView` API, so search, keyboard navigation and context menus keep working; falls back to regular cells in horizontal orientation. Card text is cached per note version (path + modification date).

### 4. Editor text brightness (Editor pane)
**Text Brightness** slider dims the editor's base text color (alpha on `NotesTextProcessor.fontColor`), applied live via the same cache-reset + refill path the code theme switch uses.

## Implementation notes
- New settings follow the existing `UserDefaultsManagement` patterns and are platform-neutral (FSNotesCore); iOS is unaffected
- Preferences controls follow the established pane patterns (hideDate checkbox, cellSpacing slider, previewFontSize popup)
- Cell styling deliberately runs in `attachHeaders`/observers rather than `draw()` — mutating fonts/constraints during the drawing pass corrupts the Auto Layout engine (verified via crash reports during development, fixed in 483e5512)
- Built and manually tested with Xcode 26.6 on macOS 15 (light + dark, list + MiniPreview, pane switching, live slider updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)