### PR TITLE
Fix very slow search when notes contain non-ASCII text

### DIFF
--- a/FSNotesCore/Business/SearchQuery.swift
+++ b/FSNotesCore/Business/SearchQuery.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Oleksandr Glushchenko. All rights reserved.
 //
 
+import Foundation
+
 class SearchQuery {
     var type: SidebarItemType? = nil
     var projects = [Project]()
@@ -87,9 +89,15 @@ class SearchQuery {
     }
 
     private func isMatched(note: Note, terms: [Substring]) -> Bool {
+        let name = note.name as NSString
+        let content = note.content.mutableString
+        let options: NSString.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+
         for term in terms {
-            if note.name.range(of: term, options: [.caseInsensitive, .diacriticInsensitive], range: nil, locale: nil) != nil ||
-                note.content.string.range(of: term, options: [.caseInsensitive, .diacriticInsensitive], range: nil, locale: nil) != nil {
+            let term = String(term)
+
+            if name.range(of: term, options: options).location != NSNotFound ||
+                content.range(of: term, options: options).location != NSNotFound {
                 continue
             }
 


### PR DESCRIPTION
## Summary

Search re-filters the whole library on every keystroke, and each pass calls `note.content.string.range(of:options:[.caseInsensitive, .diacriticInsensitive])` for every note. The trouble is that `note.content.string` is a Swift String bridged from NSString, and when a note contains any non-ASCII character (emoji, curly quotes, accents), Swift's `range(of:)` takes a very slow path: it walks the text one character at a time with an objc_msgSend per character, and it re-bridges the note's full content on every keystroke on top of that.

The cost shows up when the search term is rare or absent, because that forces a complete scan of every note's content. Common words match within the first few lines and return quickly, which is probably why this is easy to miss. On my library (~1,400 notes) a search for a term that appears in only a handful of notes takes about 14 seconds per pass. Since each new keystroke cancels the pass in flight, the note list freezes on the results of the first letter or two and never narrows while you type, so it reads as "search is broken" rather than "search is slow".

Sampling the search operation puts nearly all the time under `SearchQuery.isFit` → `StringProtocol.range` → `_StringGuts._foreignOpaqueCharacterStride` → `-[__NSCFString characterAtIndex:]`.

## Fix

Do the lookup with `NSString.range(of:options:)` instead, and read `note.content.mutableString` so nothing gets bridged or copied per keystroke. Same options, same match semantics, identical result sets in my testing. Just CoreFoundation's optimized search in place of the Swift slow path.

On my library, typing "vanta" at ~50 ms per character: correct results appear ~14 s after the last keystroke before, ~0.3 s after. On the synthetic corpus below: ~2.0 s before, ~0.14 s after.

## Repro

No real notes needed. This generates a corpus with a little non-ASCII sprinkled in, which is enough to force the slow path:

```python
#!/usr/bin/env python3
import os, random

random.seed(1)
words = "meeting budget travel recipe garden camera music letter project window".split()
out = os.path.expanduser("~/fsnotes-search-test")
os.makedirs(out, exist_ok=True)

for i in range(2500):
    title = f"note {i:04d} {random.choice(words)}"
    body = " ".join(random.choice(words) for _ in range(1500))
    body = body.replace("budget", "“budget” 😀")
    with open(os.path.join(out, title + ".md"), "w") as f:
        f.write(f"# {title}\n\n{body}\n")

print("wrote 2500 notes to", out)
```

Point FSNotes at that folder and type "polaroid" into search at normal speed. The word appears in none of the notes, so every keystroke re-scans all content: the list freezes while you type and results arrive a couple of seconds after the last letter. With this change the list keeps up with typing. Searching for a common word like "recipe" is fast either way, which is what makes the bug feel intermittent.
