### PR TITLE
Preserve formatting when moving selected lines up

### DIFF
--- a/FSNotes/View/EditTextView+MoveLines.swift
+++ b/FSNotes/View/EditTextView+MoveLines.swift
@@ -64,7 +64,7 @@ extension EditTextView {
         
         newContent.saveData()
         if shouldChangeText(in: combinedRange, replacementString: newContent.string) {
-            insertText(newContent, replacementRange: combinedRange)
+            textStorage.replaceCharacters(in: combinedRange, with: newContent)
             didChangeText()
         }
         


### PR DESCRIPTION
Fixes #1987.

`moveSelectedLinesUp()` reconstructed the correct attributed content but inserted it through `NSTextView.insertText`, allowing editor attributes to be reapplied. Moving lines down already avoids this by replacing the range directly in `textStorage`.

This change makes the upward operation use the same attributed replacement path, preserving formatting in both directions.

Verification:
- Built the FSNotes macOS scheme successfully
- Confirmed the upward and downward operations now use the same attributed-text replacement behavior